### PR TITLE
Sit mod calc changed to optional flip

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -10,7 +10,11 @@
       "characterClasses": "Character Classes",
       "characterClassesHint": "Character classes available to PCs and some NPCs.",
       "autoCalcAc": "Auto-calculate Armor Class",
-      "autoCalcAcHint": "Use 'equipped' status of armor and shields to calculate AC. Note: This function may not work correctly with certain magic items, depending on whether or not they should stack with other protective items."
+      "autoCalcAcHint": "Use 'equipped' status of armor and shields to calculate AC. N.B.: This function may not work correctly with certain magic item combinations, depending on whether or not they should stack with other protective items. But the majority of cases should work correctly.",
+      "enableAttrChecks": "Enable basic attribute checks",
+      "enableAttrChecksHint": "This option allows players to click an attribute name to do a 3d6 or d20 roll-under check. N.B.: Aside from the optional 3d6 concentration check for spellcasters taking damage, these are not actually part of the rules as written, so consider this a 'home-brew' option.",
+      "flipRollUnderMods": "Reverse situational modifiers on roll-under checks",
+      "flipRollUnderModsHint": "For roll-under checks, reverse the sign on situational modifiers so that a positive number is treated as a bonus (subtracted from the roll) and a negative number is treated as a penalty (added to the roll). Other modifiers applied from attributes or items are automatically handled this way."
     },
     "tabs": {
       "abilities": "Abilities",

--- a/module/dice.mjs
+++ b/module/dice.mjs
@@ -1,12 +1,12 @@
-import { HYP3E } from "./helpers/config.mjs";
+import { HYP3E } from "./helpers/config.mjs"
 
 export class Hyp3eDice {
   /**
-   * Handle attack and check dialogs
+   * Handle item and ability check dialogs
    * @param dataset
    */
   static async ShowBasicRollDialog(dataset) {
-    // Default rollMode to pulic roll, the user can change it in the roll dialog
+    // Default rollMode to public roll, the user can change it in the roll dialog
     let rollMode = "publicroll"
     if (dataset.rollMode) {
       rollMode = dataset.rollMode
@@ -17,12 +17,11 @@ export class Hyp3eDice {
       rollModes: CONFIG.Dice.rollModes,
       rollMode: rollMode
     }
-    console.log("Roll-dialog Dataset: ", dataset)
+    if (CONFIG.HYP3E.debugMessages) { console.log("Check roll dialog dataset: ", dataset) }
     const template = `${HYP3E.systemRoot}/templates/dialog/roll-dialog.hbs`
     const dialogHtml = await renderTemplate(template, dialogData)
-    // console.log("Dialog HTML:", dialogHtml)
 
-    // Roll dialog for attacks, item and ability checks
+    // Roll dialog for item and ability checks
     return new Promise((resolve, reject) => {
       const rollDialog = new Dialog({
         title: `${dataset.label}`,
@@ -32,14 +31,15 @@ export class Hyp3eDice {
             icon: '<i class="fas fa-dice-d20"></i>',
             label: "Roll",
             callback: (html) => {
-              const formElement = html[0].querySelector('form');
-              const formData = new FormDataExtended(formElement);
-              const formDataObj = formData.object;
+              const formElement = html[0].querySelector('form')
+              const formData = new FormDataExtended(formElement)
+              const formDataObj = formData.object
               // No situational modifier? Set it to 0
               if (formDataObj.sitMod == '') { formDataObj.sitMod = 0 }
-              console.log('Form data object:', formDataObj);
-              console.log("Rolling " + dataset.roll + " + " + formDataObj.sitMod + " ...")
-              // ui.notifications.info("Rolling " + dataset.roll + " + " + formDataObj.sitMod + " ...")
+              if (CONFIG.HYP3E.debugMessages) { 
+                console.log('Form data object:', formDataObj) 
+                console.log("Rolling " + dataset.roll + " - " + formDataObj.sitMod + " ...")
+              }
               resolve(formDataObj)
             }
           },
@@ -47,8 +47,7 @@ export class Hyp3eDice {
             icon: '<i class="fas fa-times"></i>',
             label: "Cancel",
             callback: (html) => {
-              console.log("Roll canceled!"); 
-              // ui.notifications.info("Roll canceled!")
+              if (CONFIG.HYP3E.debugMessages) { console.log("Roll canceled!") }
               reject()
             }
           }
@@ -56,8 +55,64 @@ export class Hyp3eDice {
         default: "roll",
         render: html => console.log("Register interactivity in the rendered dialog"),
         close: html => console.log("Dialog closed")
-      });
-      rollDialog.render(true);
+      })
+      rollDialog.render(true)
+    })
+  }
+
+  /**
+   * Handle attack dialogs
+   * @param dataset
+   */
+  static async ShowAttackRollDialog(dataset) {
+    // Default rollMode to public roll, the user can change it in the roll dialog
+    let rollMode = "publicroll"
+    let dialogData = {
+      roll: dataset.roll,
+      dataset: dataset,
+      rollModes: CONFIG.Dice.rollModes,
+      rollMode: rollMode
+    }
+    if (CONFIG.HYP3E.debugMessages) { console.log("Attack roll dialog dataset: ", dataset) }
+    const template = `${HYP3E.systemRoot}/templates/dialog/roll-dialog.hbs`
+    const dialogHtml = await renderTemplate(template, dialogData)
+
+    // Roll dialog for attacks
+    return new Promise((resolve, reject) => {
+      const rollDialog = new Dialog({
+        title: `${dataset.label}`,
+        content: dialogHtml,
+        buttons: {
+          roll: {
+            icon: '<i class="fas fa-dice-d20"></i>',
+            label: "Attack",
+            callback: (html) => {
+              const formElement = html[0].querySelector('form')
+              const formData = new FormDataExtended(formElement)
+              const formDataObj = formData.object
+              // No situational modifier? Set it to 0
+              if (formDataObj.sitMod == '') { formDataObj.sitMod = 0 }
+              if (CONFIG.HYP3E.debugMessages) { 
+                console.log('Form data object:', formDataObj) 
+                console.log("Rolling " + dataset.roll + " + " + formDataObj.sitMod + " ...")
+              }
+              resolve(formDataObj)
+            }
+          },
+          cancel: {
+            icon: '<i class="fas fa-times"></i>',
+            label: "Cancel",
+            callback: (html) => {
+              if (CONFIG.HYP3E.debugMessages) { console.log("Roll canceled!") }
+              reject()
+            }
+          }
+        },
+        default: "roll",
+        render: html => console.log("Register interactivity in the rendered dialog"),
+        close: html => console.log("Dialog closed")
+      })
+      rollDialog.render(true)
     })
   }
 
@@ -66,11 +121,8 @@ export class Hyp3eDice {
    * @param dataset
    */
   static async ShowSpellcastingDialog(dataset) {
-    // Default rollMode to pulic roll, the user can change it in the roll dialog
+    // Default rollMode to public roll, the user can change it in the roll dialog
     let rollMode = "publicroll"
-    // if (dataset.rollMode) {
-    //   rollMode = dataset.rollMode
-    // }
     let dialogData = {
       roll: dataset.roll,
       enableRoll: dataset.enableRoll,
@@ -78,10 +130,9 @@ export class Hyp3eDice {
       rollModes: CONFIG.Dice.rollModes,
       rollMode: rollMode
     }
-    console.log("Roll-dialog Dataset: ", dataset)
+    if (CONFIG.HYP3E.debugMessages) { console.log("Spellcasting roll dialog dataset: ", dataset) }
     const template = `${HYP3E.systemRoot}/templates/dialog/roll-dialog.hbs`
     const dialogHtml = await renderTemplate(template, dialogData)
-    // console.log("Dialog HTML:", dialogHtml)
 
     // Roll dialog for casting spells
     return new Promise((resolve, reject) => {
@@ -93,14 +144,15 @@ export class Hyp3eDice {
             icon: '<i class="fas fa-scroll"></i>',
             label: "Cast",
             callback: (html) => {
-              const formElement = html[0].querySelector('form');
-              const formData = new FormDataExtended(formElement);
-              const formDataObj = formData.object;
+              const formElement = html[0].querySelector('form')
+              const formData = new FormDataExtended(formElement)
+              const formDataObj = formData.object
               // No situational modifier? Set it to 0
               if (formDataObj.sitMod == '') { formDataObj.sitMod = 0 }
-              console.log('Form data object:', formDataObj);
-              console.log("Rolling " + dataset.roll + " + " + formDataObj.sitMod + " ...")
-              // ui.notifications.info("Rolling " + dataset.roll + " + " + formDataObj.sitMod + " ...")
+              if (CONFIG.HYP3E.debugMessages) {
+                console.log('Form data object:', formDataObj)
+                console.log("Rolling " + dataset.roll + " + " + formDataObj.sitMod + " ...")
+              }
               resolve(formDataObj)
             }
           },
@@ -108,8 +160,7 @@ export class Hyp3eDice {
             icon: '<i class="fas fa-times"></i>',
             label: "Cancel",
             callback: (html) => {
-              console.log("Roll canceled!"); 
-              // ui.notifications.info("Roll canceled!")
+              console.log("Roll canceled!")
               reject()
             }
           }
@@ -117,8 +168,8 @@ export class Hyp3eDice {
         default: "roll",
         render: html => console.log("Register interactivity in the rendered dialog"),
         close: html => console.log("Dialog closed")
-      });
-      rollDialog.render(true);
+      })
+      rollDialog.render(true)
     })
   }
   
@@ -138,10 +189,9 @@ export class Hyp3eDice {
       rollModes: CONFIG.Dice.rollModes,
       rollMode: rollMode
     }
-    console.log("Roll-dialog Dataset: ", dataset)
-    const template = `${HYP3E.systemRoot}/templates/dialog/roll-dialog.hbs`;
-    const dialogHtml = await renderTemplate(template, dialogData);
-    // console.log("Dialog HTML:", dialogHtml)
+    if (CONFIG.HYP3E.debugMessages) { console.log("Save roll dialog dataset: ", dataset) }
+    const template = `${HYP3E.systemRoot}/templates/dialog/roll-dialog.hbs`
+    const dialogHtml = await renderTemplate(template, dialogData)
 
     // Roll dialog for saving throws, with save modifiers
     return new Promise((resolve, reject) => {
@@ -153,14 +203,15 @@ export class Hyp3eDice {
             icon: '<i class="fas fa-dice-d20"></i>',
             label: "Roll",
             callback: (html) => {
-              const formElement = html[0].querySelector('form');
-              const formData = new FormDataExtended(formElement);
-              const formDataObj = formData.object;
+              const formElement = html[0].querySelector('form')
+              const formData = new FormDataExtended(formElement)
+              const formDataObj = formData.object
               // No situational modifier? Set it to 0
               if (formDataObj.sitMod == '') { formDataObj.sitMod = 0 }
-              console.log('Form data object:', formDataObj);
-              console.log("Rolling basic save: " + dataset.roll + " + " + formDataObj.sitMod + " ...")
-              // ui.notifications.info("Rolling " + dataset.roll + " + " + formDataObj.sitMod + " ...")
+              if (CONFIG.HYP3E.debugMessages) {
+                console.log('Form data object:', formDataObj)
+                console.log("Rolling basic save: " + dataset.roll + " + " + formDataObj.sitMod + " ...")
+              }
               resolve(formDataObj)
             }
           },
@@ -168,15 +219,16 @@ export class Hyp3eDice {
             icon: '<i class="fas fa-dice-d20"></i>',
             label: "Avoidance Mod",
             callback: (html) => {
-              const formElement = html[0].querySelector('form');
-              const formData = new FormDataExtended(formElement);
-              const formDataObj = formData.object;
+              const formElement = html[0].querySelector('form')
+              const formData = new FormDataExtended(formElement)
+              const formDataObj = formData.object
               formDataObj.avoidMod = dataset.avoidMod
               // No situational modifier? Set it to 0
               if (formDataObj.sitMod == '') { formDataObj.sitMod = 0 }
-              console.log('Form data object:', formDataObj);
-              console.log("Rolling with Avoidance mod: " + dataset.roll + " + " + formDataObj.avoidMod + " + " + formDataObj.sitMod + " ...")
-              // ui.notifications.info("Rolling " + dataset.roll + " + " + formDataObj.avoidMod + " + " + formDataObj.sitMod + " ...")
+              if (CONFIG.HYP3E.debugMessages) {
+                console.log('Form data object:', formDataObj)
+                console.log("Rolling save with Avoidance mod: " + dataset.roll + " + " + formDataObj.avoidMod + " + " + formDataObj.sitMod + " ...")
+              }
               resolve(formDataObj)
             }
           },
@@ -184,15 +236,16 @@ export class Hyp3eDice {
             icon: '<i class="fas fa-dice-d20"></i>',
             label: "Poison/Rad Mod",
             callback: (html) => {
-              const formElement = html[0].querySelector('form');
-              const formData = new FormDataExtended(formElement);
-              const formDataObj = formData.object;
+              const formElement = html[0].querySelector('form')
+              const formData = new FormDataExtended(formElement)
+              const formDataObj = formData.object
               formDataObj.poisonMod = dataset.poisonMod
               // No situational modifier? Set it to 0
               if (formDataObj.sitMod == '') { formDataObj.sitMod = 0 }
-              console.log('Form data object:', formDataObj);
-              console.log("Rolling with Poison/Radiation mod: " + dataset.roll + " + " + formDataObj.poisonMod + " + " + formDataObj.sitMod + " ...")
-              // ui.notifications.info("Rolling " + dataset.roll + " + " + formDataObj.poisonMod + " + " + formDataObj.sitMod + " ...")
+              if (CONFIG.HYP3E.debugMessages) {
+                console.log('Form data object:', formDataObj)
+                console.log("Rolling save with Poison/Radiation mod: " + dataset.roll + " + " + formDataObj.poisonMod + " + " + formDataObj.sitMod + " ...")
+              }
               resolve(formDataObj)
             }
           },
@@ -200,15 +253,16 @@ export class Hyp3eDice {
             icon: '<i class="fas fa-dice-d20"></i>',
             label: "Willpower Mod",
             callback: (html) => {
-              const formElement = html[0].querySelector('form');
-              const formData = new FormDataExtended(formElement);
-              const formDataObj = formData.object;
+              const formElement = html[0].querySelector('form')
+              const formData = new FormDataExtended(formElement)
+              const formDataObj = formData.object
               formDataObj.willMod = dataset.willMod
               // No situational modifier? Set it to 0
               if (formDataObj.sitMod == '') { formDataObj.sitMod = 0 }
-              console.log('Form data object:', formDataObj);
-              console.log("Rolling with Willpower mod: " + dataset.roll + " + " + formDataObj.willMod + " + " + formDataObj.sitMod + " ...")
-              // ui.notifications.info("Rolling " + dataset.roll + " + " + formDataObj.willMod + " + " + formDataObj.sitMod + " ...")
+              if (CONFIG.HYP3E.debugMessages) {
+                console.log('Form data object:', formDataObj)
+                console.log("Rolling save with Willpower mod: " + dataset.roll + " + " + formDataObj.willMod + " + " + formDataObj.sitMod + " ...")
+              }
               resolve(formDataObj)
             }
           },
@@ -216,8 +270,7 @@ export class Hyp3eDice {
             icon: '<i class="fas fa-times"></i>',
             label: "Cancel",
             callback: (html) => {
-              console.log("Roll canceled!"); 
-              // ui.notifications.info("Roll canceled!")
+              console.log("Roll canceled!")
               reject()
             }
           }
@@ -225,8 +278,8 @@ export class Hyp3eDice {
         default: "roll",
         render: html => console.log("Register interactivity in the rendered dialog"),
         close: html => console.log("Dialog closed")
-      });
-      rollDialog.render(true);
+      })
+      rollDialog.render(true)
     })
   }
 }

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -409,10 +409,17 @@ export class Hyp3eItem extends Item {
     console.log("Item roll data:", rollData)
     // Declare vars
     let rollFormula
-    
+    let debugCheckRollFormula = ""
+
     // Setup roll formula
     label = `${itemName} roll...`
-    rollFormula = `${rollData.item.formula} + ${rollData.item.sitMod}`
+    if (CONFIG.HYP3E.flipRollUnderMods) {
+      if (CONFIG.HYP3E.debugMessages) { debugCheckRollFormula = `Check Formula: ${rollData.item.formula} - sitMod` }
+      rollFormula = `${rollData.item.formula} - ${rollData.item.sitMod}`
+    } else {
+      if (CONFIG.HYP3E.debugMessages) { debugCheckRollFormula = `Check Formula: ${rollData.item.formula} + sitMod` }
+      rollFormula = `${rollData.item.formula} + ${rollData.item.sitMod}`
+    }
 
     console.log("Roll formula:", rollFormula)
     // Invoke the roll and submit it to chat.

--- a/module/hyp3e.mjs
+++ b/module/hyp3e.mjs
@@ -31,33 +31,7 @@ Hooks.once('init', async function() {
     scope: "world",
     type: Boolean,
     config: true,
-  });
-  // Human races
-  game.settings.register(game.system.id, "races", {
-    name: game.i18n.localize("HYP3E.settings.races"),
-    hint: game.i18n.localize("HYP3E.settings.racesHint"),
-    default: "Common (Mixed), Amazon, Atlantean, Esquimaux, Hyperborean, Ixian, Kelt, Kimmerian, Kimmeri-Kelt, Pict, Pict (Half-Blood), Viking, Anglo-Saxon, Carolingian Frank, Carthaginian, Esquimaux-Ixian, Greek, Lapp, Lemurian, Moor, Mu, Oon, Roman, Tlingit, Yakut",
-    scope: "world",
-    type: String,
-    config: true,
-  });
-  // Languages
-  game.settings.register(game.system.id, "languages", {
-    name: game.i18n.localize("HYP3E.settings.languages"),
-    hint: game.i18n.localize("HYP3E.settings.languagesHint"),
-    default: "Common, Berber, Esquimaux (Coastal), Esquimaux (Tundra), Esquimaux-Ixian (pidgin), Hellenic (Amazon), Hellenic (Atlantean), Hellenic (Greek), Hellenic (Hyperborean), Hellenic (Kimmerian), Keltic (Goidelic), Keltic (Pictish), Latin, Lemurian, Muat, Old Norse (Anglo-Saxon), Old Norse (Viking), Oonat, Thracian (Ixian), Thracian (Kimmerian), Tlingit, Uralic (Lapp), Uralic (Yakut)",
-    scope: "world",
-    type: String,
-    config: true,
-  });
-  // Classes
-  game.settings.register(game.system.id, "characterClasses", {
-    name: game.i18n.localize("HYP3E.settings.characterClasses"),
-    hint: game.i18n.localize("HYP3E.settings.characterClassesHint"),
-    default: "Assassin, Barbarian, Bard, Berserker, Cataphract, Cleric, Cryomancer, Druid, Fighter, Huntsman, Illusionist, Legerdemainist, Magician, Monk, Necromancer, Paladin, Priest, Purloiner, Pyromancer, Ranger, Runegraver, Scout, Shaman, Thief, Warlock, Witch",
-    scope: "world",
-    type: String,
-    config: true,
+    requiresReload: true,
   });
   // Automatic Armor Class calculation
   game.settings.register(game.system.id, "autoCalcAc", {
@@ -67,6 +41,62 @@ Hooks.once('init', async function() {
     scope: "world",
     type: Boolean,
     config: true,
+    requiresReload: true,
+  });
+  // Enable basic attribute checks
+  game.settings.register(game.system.id, "enableAttrChecks", {
+    name: game.i18n.localize("HYP3E.settings.enableAttrChecks"),
+    hint: game.i18n.localize("HYP3E.settings.enableAttrChecksHint"),
+    default: false,
+    scope: "world",
+    type: String,
+    choices: {
+      "": "Disabled",
+      "3d6": "3d6 roll-under",
+      "d20": "d20 roll-under"
+    },
+    config: true,
+    requiresReload: true,
+  });
+  // Reverse situational modifiers on roll-under checks
+  game.settings.register(game.system.id, "flipRollUnderMods", {
+    name: game.i18n.localize("HYP3E.settings.flipRollUnderMods"),
+    hint: game.i18n.localize("HYP3E.settings.flipRollUnderModsHint"),
+    default: true,
+    scope: "world",
+    type: Boolean,
+    config: true,
+    requiresReload: true,
+  });
+  // Human races
+  game.settings.register(game.system.id, "races", {
+    name: game.i18n.localize("HYP3E.settings.races"),
+    hint: game.i18n.localize("HYP3E.settings.racesHint"),
+    default: "Common (Mixed), Amazon, Atlantean, Esquimaux, Hyperborean, Ixian, Kelt, Kimmerian, Kimmeri-Kelt, Pict, Pict (Half-Blood), Viking, Anglo-Saxon, Carolingian Frank, Carthaginian, Esquimaux-Ixian, Greek, Lapp, Lemurian, Moor, Mu, Oon, Roman, Tlingit, Yakut",
+    scope: "world",
+    type: String,
+    config: true,
+    requiresReload: true,
+  });
+  // Languages
+  game.settings.register(game.system.id, "languages", {
+    name: game.i18n.localize("HYP3E.settings.languages"),
+    hint: game.i18n.localize("HYP3E.settings.languagesHint"),
+    default: "Common, Berber, Esquimaux (Coastal), Esquimaux (Tundra), Esquimaux-Ixian (pidgin), Hellenic (Amazon), Hellenic (Atlantean), Hellenic (Greek), Hellenic (Hyperborean), Hellenic (Kimmerian), Keltic (Goidelic), Keltic (Pictish), Latin, Lemurian, Muat, Old Norse (Anglo-Saxon), Old Norse (Viking), Oonat, Thracian (Ixian), Thracian (Kimmerian), Tlingit, Uralic (Lapp), Uralic (Yakut)",
+    scope: "world",
+    type: String,
+    config: true,
+    requiresReload: true,
+  });
+  // Classes
+  game.settings.register(game.system.id, "characterClasses", {
+    name: game.i18n.localize("HYP3E.settings.characterClasses"),
+    hint: game.i18n.localize("HYP3E.settings.characterClassesHint"),
+    default: "Assassin, Barbarian, Bard, Berserker, Cataphract, Cleric, Cryomancer, Druid, Fighter, Huntsman, Illusionist, Legerdemainist, Magician, Monk, Necromancer, Paladin, Priest, Purloiner, Pyromancer, Ranger, Runegraver, Scout, Shaman, Thief, Warlock, Witch",
+    scope: "world",
+    type: String,
+    config: true,
+    requiresReload: true,
   });
 
   // If we ever need migration scripts, use this version number for comparison
@@ -142,6 +172,21 @@ Hooks.once("ready", async function() {
   const debugMessages = game.settings.get(game.system.id, "debugMessages");
   CONFIG.HYP3E.debugMessages = debugMessages;
 
+  // Automatically calculate AC
+  const autoCalcAc = game.settings.get(game.system.id, "autoCalcAc");
+  CONFIG.HYP3E.autoCalcAc = autoCalcAc;
+  if (CONFIG.HYP3E.debugMessages) { console.log("CONFIG Auto-calculate AC:", CONFIG.HYP3E.autoCalcAc) }
+
+  // Enable basic attribute checks
+  const enableAttrChecks = game.settings.get(game.system.id, "enableAttrChecks");
+  CONFIG.HYP3E.enableAttrChecks = enableAttrChecks;
+  if (CONFIG.HYP3E.debugMessages) { console.log("CONFIG Enable basic attribute checks:", CONFIG.HYP3E.enableAttrChecks) }
+
+  // Reverse situational modifiers on roll-under checks
+  const flipRollUnderMods = game.settings.get(game.system.id, "flipRollUnderMods");
+  CONFIG.HYP3E.flipRollUnderMods = flipRollUnderMods;
+  if (CONFIG.HYP3E.debugMessages) { console.log("CONFIG Reverse situational modifiers on roll-under checks:", CONFIG.HYP3E.flipRollUnderMods) }
+
   // Load races list
   const races = game.settings.get(game.system.id, "races");
   if (races != "") {
@@ -168,11 +213,6 @@ Hooks.once("ready", async function() {
     classArray.forEach((l, i) => (CONFIG.HYP3E.characterClasses[l.trim()] = l.trim()));
     if (CONFIG.HYP3E.debugMessages) { console.log("CONFIG Classes:", CONFIG.HYP3E.characterClasses) }
   }
-
-  // Automatically calculate AC
-  const autoCalcAc = game.settings.get(game.system.id, "autoCalcAc");
-  CONFIG.HYP3E.autoCalcAc = autoCalcAc;
-  if (CONFIG.HYP3E.debugMessages) { console.log("CONFIG Auto-calculate AC:", CONFIG.HYP3E.autoCalcAc) }
 
   // Load blind roll options
   if (CONFIG.HYP3E.blindRollOpts) {

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -100,7 +100,10 @@ export class Hyp3eActorSheet extends ActorSheet {
       if (CONFIG.HYP3E.debugMessages) { console.log("Money Types:", k, v, v.label) }
     }
 
-    // Character classes, races, and languages are global system settings
+    // The following are global system settings
+    context.enableAttrChecks = CONFIG.HYP3E.enableAttrChecks
+    if (CONFIG.HYP3E.debugMessages) { console.log("Enable attributes checks:", context.enableAttrChecks) }
+
     context.characterClasses = CONFIG.HYP3E.characterClasses
     if (CONFIG.HYP3E.debugMessages) { console.log("Actor sheet class list:", context.characterClasses) }
 
@@ -703,7 +706,7 @@ export class Hyp3eActorSheet extends ActorSheet {
             dataset.label = `${mastery} with ${itemName}...`
             dataset.roll = item.system.formula
             // dataset.enableRoll = true
-            rollResponse = await Hyp3eDice.ShowBasicRollDialog(dataset);
+            rollResponse = await Hyp3eDice.ShowAttackRollDialog(dataset);
           } else if (item.type == "spell") {
             dataset.label = `Cast spell ${itemName}...`
             if (item.system.formula > "") {
@@ -740,7 +743,12 @@ export class Hyp3eActorSheet extends ActorSheet {
           if (CONFIG.HYP3E.debugMessages) { console.log("Dataset:", dataset) }
           rollResponse = await Hyp3eDice.ShowBasicRollDialog(dataset);
           // Add situational modifier from the dice dialog
-          rollFormula = `${dataset.roll} + ${rollResponse.sitMod}`;
+          if (CONFIG.HYP3E.flipRollUnderMods) {
+            rollFormula = `${dataset.roll} - ${rollResponse.sitMod}`
+          } else {
+            rollFormula = `${dataset.roll} + ${rollResponse.sitMod}`;
+          }
+          
           break;
 
         case "attack":
@@ -749,7 +757,7 @@ export class Hyp3eActorSheet extends ActorSheet {
           // dataset.enableRoll = true
           // Log the dataset before the dialog renders
           if (CONFIG.HYP3E.debugMessages) { console.log("Dataset:", dataset) }
-          rollResponse = await Hyp3eDice.ShowBasicRollDialog(dataset);
+          rollResponse = await Hyp3eDice.ShowAttackRollDialog(dataset);
           // Add situational modifier from the dice dialog
           rollFormula = `${dataset.roll} + ${rollResponse.sitMod}`;
           break;

--- a/templates/actor/parts/actor-attributes.hbs
+++ b/templates/actor/parts/actor-attributes.hbs
@@ -9,9 +9,9 @@
 <div class="abilities flexcol">
   <!-- Strength -->
   <div class="attribute-row flexrow flex-group-center">
-    <span class="rollable flex" data-roll="3d6" data-roll-type="check" data-roll-target="{{system.attributes.str.value}}" data-label="{{localize 'HYP3E.attributes.str.check'}}">
+    <span class="{{#if enableAttrChecks}}rollable{{/if}} flex" data-roll="{{enableAttrChecks}}" data-roll-type="check" data-roll-target="{{system.attributes.str.value}}" data-label="{{localize 'HYP3E.attributes.str.check'}}">
       <label for="system.attributes.str.value" class="attribute-label">{{localize 'HYP3E.attributes.str.abbrev'}}</label>
-      <i class="fas fa-dice"></i>
+      {{#if enableAttrChecks}}<i class="fas fa-dice"></i>{{/if}}
     </span>
     <div class="attribute-value">
       <input type="text" name="system.attributes.str.value" value="{{system.attributes.str.value}}" data-dtype="Number"/>
@@ -38,9 +38,9 @@
   </div>
   <!-- Dexterity -->
   <div class="attribute-row flexrow flex-group-center">
-    <span class="rollable flex" data-roll="3d6" data-roll-type="check" data-roll-target="{{system.attributes.dex.value}}" data-label="{{localize 'HYP3E.attributes.dex.check'}}">
+    <span class="{{#if enableAttrChecks}}rollable{{/if}} flex" data-roll="{{enableAttrChecks}}" data-roll-type="check" data-roll-target="{{system.attributes.dex.value}}" data-label="{{localize 'HYP3E.attributes.dex.check'}}">
       <label for="system.attributes.dex.value" class="attribute-label">{{localize 'HYP3E.attributes.dex.abbrev'}}</label>
-      <i class="fas fa-dice"></i>
+      {{#if enableAttrChecks}}<i class="fas fa-dice"></i>{{/if}}
     </span>
     <div class="attribute-value">
       <input type="text" name="system.attributes.dex.value" value="{{system.attributes.dex.value}}" data-dtype="Number"/>
@@ -67,9 +67,9 @@
   </div>
   <!-- Constitution -->
   <div class="attribute-row flexrow flex-group-center">
-    <span class="rollable flex" data-roll="3d6" data-roll-type="check" data-roll-target="{{system.attributes.con.value}}" data-label="{{localize 'HYP3E.attributes.con.check'}}">
+    <span class="{{#if enableAttrChecks}}rollable{{/if}} flex" data-roll="{{enableAttrChecks}}" data-roll-type="check" data-roll-target="{{system.attributes.con.value}}" data-label="{{localize 'HYP3E.attributes.con.check'}}">
       <label for="system.attributes.con.value" class="attribute-label">{{localize 'HYP3E.attributes.con.abbrev'}}</label>
-      <i class="fas fa-dice"></i>
+      {{#if enableAttrChecks}}<i class="fas fa-dice"></i>{{/if}}
     </span>
     <div class="attribute-value">
       <input type="text" name="system.attributes.con.value" value="{{system.attributes.con.value}}" data-dtype="Number"/>
@@ -97,9 +97,9 @@
   </div>
   <!-- Intelligence -->
   <div class="attribute-row flexrow flex-group-center">
-    <span class="rollable flex" data-roll="3d6" data-roll-type="check" data-roll-target="{{system.attributes.int.value}}" data-label="{{localize 'HYP3E.attributes.int.check'}}">
+    <span class="{{#if enableAttrChecks}}rollable{{/if}} flex" data-roll="{{enableAttrChecks}}" data-roll-type="check" data-roll-target="{{system.attributes.int.value}}" data-label="{{localize 'HYP3E.attributes.int.check'}}">
       <label for="system.attributes.int.value" class="attribute-label">{{localize 'HYP3E.attributes.int.abbrev'}}</label>
-      <i class="fas fa-dice"></i>
+      {{#if enableAttrChecks}}<i class="fas fa-dice"></i>{{/if}}
     </span>
     <div class="attribute-value">
       <input type="text" name="system.attributes.int.value" value="{{system.attributes.int.value}}" data-dtype="Number"/>
@@ -130,9 +130,9 @@
   </div>
   <!-- Wisdom -->
   <div class="attribute-row flexrow flex-group-center">
-    <span class="rollable flex" data-roll="3d6" data-roll-type="check" data-roll-target="{{system.attributes.wis.value}}" data-label="{{localize 'HYP3E.attributes.wis.check'}}">
+    <span class="{{#if enableAttrChecks}}rollable{{/if}} flex" data-roll="{{enableAttrChecks}}" data-roll-type="check" data-roll-target="{{system.attributes.wis.value}}" data-label="{{localize 'HYP3E.attributes.wis.check'}}">
       <label for="system.attributes.wis.value" class="attribute-label">{{localize 'HYP3E.attributes.wis.abbrev'}}</label>
-      <i class="fas fa-dice"></i>
+      {{#if enableAttrChecks}}<i class="fas fa-dice"></i>{{/if}}
     </span>
     <div class="attribute-value">
       <input type="text" name="system.attributes.wis.value" value="{{system.attributes.wis.value}}" data-dtype="Number"/>
@@ -163,9 +163,9 @@
   </div>
   <!-- Charisma -->
   <div class="attribute-row flexrow flex-group-center">
-    <span class="rollable flex" data-roll="3d6" data-roll-type="check" data-roll-target="{{system.attributes.cha.value}}" data-label="{{localize 'HYP3E.attributes.cha.check'}}">
+    <span class="{{#if enableAttrChecks}}rollable{{/if}} flex" data-roll="{{enableAttrChecks}}" data-roll-type="check" data-roll-target="{{system.attributes.cha.value}}" data-label="{{localize 'HYP3E.attributes.cha.check'}}">
       <label for="system.attributes.cha.value" class="attribute-label">{{localize 'HYP3E.attributes.cha.abbrev'}}</label>
-      <i class="fas fa-dice"></i>
+      {{#if enableAttrChecks}}<i class="fas fa-dice"></i>{{/if}}
     </span>
     <div class="attribute-value">
       <input type="text" name="system.attributes.cha.value" value="{{system.attributes.cha.value}}" data-dtype="Number"/>


### PR DESCRIPTION
- Added option to choose whether to reverse the sign on situational modifiers for roll-under checks. Default is 'true', i.e. flip the sign so that a positive modifier is treated as a bonus and a negative mod is a penalty.
- Added issue 11 enhancement for roll-under attribute checks: https://github.com/thurianknight/hyp3e/issues/11
