### PR TITLE
Damage Buttons 

### DIFF
--- a/css/hyp3e.css
+++ b/css/hyp3e.css
@@ -274,6 +274,14 @@ textarea {
   /* color: #e90000; */
 }
 
+.chat-button-small {
+  width: 22px;
+  height:22px;
+  font-size:10px;
+  line-height:1px
+}
+
+
 /* Styles limited to hyp3e sheets */
 .hyp3e {
   /* Example style for Hyp3e (can be removed if not needed) */

--- a/lang/en.json
+++ b/lang/en.json
@@ -16,9 +16,9 @@
       "flipRollUnderMods": "Reverse situational modifiers on roll-under checks",
       "flipRollUnderModsHint": "For roll-under checks, reverse the sign on situational modifiers so that a positive number is treated as a bonus (subtracted from the roll) and a negative number is treated as a penalty (added to the roll). Other modifiers applied from attributes or items are automatically handled this way.",
       "critHits": "Critical Hits",
-      "critHitsHint": "Show 2x and 3x damage buttons on natural 20.",
+      "critHitsHint": "Show buttons to roll critical hits on natural 20.",
       "critMiss": "Critical Misses/ Xathoqqua’s Woe",
-      "critMissHint": "Show failure button on natural 1."
+      "critMissHint": "Show buttons to roll critical miss on natural 1."
     },
     "tabs": {
       "abilities": "Abilities",

--- a/lang/en.json
+++ b/lang/en.json
@@ -330,7 +330,11 @@
         "mage": "Critical miss roll for magician",
         "fighter": "Critical miss roll for fighter",
         "other": "Critical miss roll for cleric/thief/monster"
-
+      },
+      "critHit": {
+        "mage": "Critical hit roll for magician",
+        "fighter": "Critical hit roll for fighter",
+        "other": "Critical hit roll for cleric/thief/monster"
       }
     },
     "roll": "Roll",

--- a/lang/en.json
+++ b/lang/en.json
@@ -14,7 +14,11 @@
       "enableAttrChecks": "Enable IN & WS concentration checks",
       "enableAttrChecksHint": "This option allows players to click an attribute name to do a 3d6 concentration (roll-under) check. N.B.: This is an optional rule, and is disabled by default.",
       "flipRollUnderMods": "Reverse situational modifiers on roll-under checks",
-      "flipRollUnderModsHint": "For roll-under checks, reverse the sign on situational modifiers so that a positive number is treated as a bonus (subtracted from the roll) and a negative number is treated as a penalty (added to the roll). Other modifiers applied from attributes or items are automatically handled this way."
+      "flipRollUnderModsHint": "For roll-under checks, reverse the sign on situational modifiers so that a positive number is treated as a bonus (subtracted from the roll) and a negative number is treated as a penalty (added to the roll). Other modifiers applied from attributes or items are automatically handled this way.",
+      "critHits": "Critical Hits",
+      "critHitsHint": "Show 2x and 3x damage buttons on natural 20.",
+      "critMiss": "Critical Misses/ Xathoqqua’s Woe",
+      "critMissHint": "Show failure button on natural 1."
     },
     "tabs": {
       "abilities": "Abilities",
@@ -312,7 +316,18 @@
       "unarmored": "Unarmored"
     },
     "attack": {
-      "add": "Add Attack"
+      "add": "Add Attack",
+      "critMiss": {
+        "name": "Critical Miss",
+        "badMiss": "Bad miss",
+        "dropWeapon" : "Drop weapon: {feet} away to {direction}.",
+        "stumble": "Awkward stumble. One adjacent gets one free attack. No further attacks for rest of round.",
+        "tripFall" : "Trip and fall. Prone: -4 AC/ no DX bonus for remainder of round and until next action.",
+        "hitAlly": "Hit ally: (closest for melee, closest adjacent for ranged. Regular hit.",
+        "hitAllyCrit": "Hit ally: (closest for melee, closest adjacent for ranged. <b>Critical Hit</b>.",
+        "hitSelf": "Hit self: Regular hit.",
+        "hitSelfCrit": "Hit self: <b>Critical Hit</b>."
+      }
     },
     "roll": "Roll",
     "rollFormula": "Roll Formula",

--- a/lang/en.json
+++ b/lang/en.json
@@ -320,13 +320,17 @@
       "critMiss": {
         "name": "Critical Miss",
         "badMiss": "Bad miss",
-        "dropWeapon" : "Drop weapon: {feet} away to {direction}.",
+        "dropWeapon" : "Drop weapon: {feet} feet away to {direction}.",
         "stumble": "Awkward stumble. One adjacent gets one free attack. No further attacks for rest of round.",
         "tripFall" : "Trip and fall. Prone: -4 AC/ no DX bonus for remainder of round and until next action.",
-        "hitAlly": "Hit ally: (closest for melee, closest adjacent for ranged. Regular hit.",
-        "hitAllyCrit": "Hit ally: (closest for melee, closest adjacent for ranged. <b>Critical Hit</b>.",
+        "hitAlly": "Hit ally: closest for melee, closest adjacent for ranged. Regular hit.",
+        "hitAllyCrit": "Hit ally: closest for melee, closest adjacent for ranged. <b>Critical Hit</b>.",
         "hitSelf": "Hit self: Regular hit.",
-        "hitSelfCrit": "Hit self: <b>Critical Hit</b>."
+        "hitSelfCrit": "Hit self: <b>Critical Hit</b>.",
+        "mage": "Critical miss roll for magician",
+        "fighter": "Critical miss roll for fighter",
+        "other": "Critical miss roll for cleric/thief/monster"
+
       }
     },
     "roll": "Roll",

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -571,13 +571,17 @@ export class Hyp3eActor extends Actor {
         if (CONFIG.HYP3E.debugMessages) { console.log("Damage result: ", dmgRoll) }
 
         // Render a damage chat snippet that will be added to the attack chat
-        damageChat = this.renderDamageChat(dmgRoll, debugDmgRollFormula)
+        damageChat = this.renderDamageChat(dmgRoll, debugDmgRollFormula, naturalRoll)
         // if (CONFIG.HYP3E.debugMessages) { console.log("Damage chat: ", damageChat) }
 
       }
     }
+
+    let critMissHTML = (game.settings.get(game.system.id, "critMiss") && item && naturalRoll == 1) ? 
+      "<div class='critical-miss'><h4>Xathoqqua’s Woe:</h4></div>" :
+      "";
     // Construct a custom chat card for the attack & damage
-    const attackChat = this.renderCustomChat(atkRoll, debugAtkRollFormula, "", damageChat)
+    const attackChat = this.renderCustomChat(atkRoll, debugAtkRollFormula, "", damageChat, critMissHTML);
     // if (CONFIG.HYP3E.debugMessages) { console.log("Attack chat: ", attackChat) }
 
     // Output roll result to a chat message
@@ -765,8 +769,7 @@ export class Hyp3eActor extends Actor {
   }
   
   // Render custom html for attacks and turning undead
-  renderCustomChat(roll, debugRollFormula, description, damageChat) {
-
+  renderCustomChat(roll, debugRollFormula, description, damageChat, footerHTML = "") {
     // Render the full attack-roll chat card, with damage if any
     let customChat = `
     <div class="message-content">
@@ -809,13 +812,14 @@ export class Hyp3eActor extends Actor {
         </div>
       </div>
       ${damageChat}
+      ${footerHTML}
     </div>
     `
     return customChat    
   }
 
   // Render custom html for damage rolls, which is added to the attack chat
-  renderDamageChat(dmgRoll, debugDmgRollFormula) {
+  renderDamageChat(dmgRoll, debugDmgRollFormula, naturalRoll) {
     // Render the damage-roll chat html
     let damageChat = ""
 

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -867,7 +867,7 @@ export class Hyp3eActor extends Actor {
               </section>
             </div>
             <h4 class="dice-formula"><span class="dice-damage">${dmgRoll.total} HP damage!</span>
-            <span class="damage-button" data-total="${dmgRoll.total}"></span></h4>
+            <span class="damage-button" data-total="${dmgRoll.total}" data-natural="${naturalRoll}"></span></h4>
           </div>                
         </div>
         <!--

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -580,8 +580,11 @@ export class Hyp3eActor extends Actor {
         let result = await dmgRoll.roll();
         if (CONFIG.HYP3E.debugMessages) { console.log("Damage result: ", dmgRoll) }
 
+        // Get the dice roll value of damage for x2/x3 modifier button
+        let dmgRollNatural =  dmgRoll.dice[0].total;
+
         // Render a damage chat snippet that will be added to the attack chat
-        damageChat = this.renderDamageChat(dmgRoll, debugDmgRollFormula, naturalRoll)
+        damageChat = this.renderDamageChat(dmgRoll, debugDmgRollFormula, dmgRollNatural)
         // if (CONFIG.HYP3E.debugMessages) { console.log("Damage chat: ", damageChat) }
 
       }
@@ -826,7 +829,7 @@ export class Hyp3eActor extends Actor {
   }
 
   // Render custom html for damage rolls, which is added to the attack chat
-  renderDamageChat(dmgRoll, debugDmgRollFormula, naturalRoll) {
+  renderDamageChat(dmgRoll, debugDmgRollFormula, naturalDmgRoll) {
     // Render the damage-roll chat html
     let damageChat = ""
 
@@ -867,7 +870,7 @@ export class Hyp3eActor extends Actor {
               </section>
             </div>
             <h4 class="dice-formula"><span class="dice-damage">${dmgRoll.total} HP damage!</span>
-            <span class="damage-button" data-total="${dmgRoll.total}" data-natural="${naturalRoll}"></span></h4>
+            <span class="damage-button" data-total="${dmgRoll.total}" data-natural="${naturalDmgRoll}"></span></h4>
           </div>                
         </div>
         <!--

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -498,6 +498,9 @@ export class Hyp3eActor extends Actor {
       label += `...`
     }
 
+    // Footer used for adding crit buttons (if enabled)
+    let critFooterHTML = "";
+
     // Determine hit or miss based on target AC
     let hit = false
     let tn = 20 - targetAc
@@ -506,9 +509,16 @@ export class Hyp3eActor extends Actor {
       if (CONFIG.HYP3E.debugMessages) { console.log("Natural 20 always crit hits!") }
       label += `<br /><span style='color:#00b34c'><b>Critical Hit!</b></span>`
       hit = true
+      if (game.settings.get(game.system.id, "critHit") && item) {
+        critFooterHTML = "<div class='critical-hit'><h4>Critical Hit:</h4></div>";
+      }
     } else if (naturalRoll == 1) {
       if (CONFIG.HYP3E.debugMessages) { console.log("Natural 1 always crit misses!") }
       label += "<br /><span style='color:#e90000'><b>Critical Miss!</b></span>"
+
+      if (game.settings.get(game.system.id, "critMiss") && item) {
+        critFooterHTML = "<div class='critical-miss'><h4>Xathoqqua’s Woe:</h4></div>";
+      }
     } else if (atkRoll.total >= tn) {
       if (CONFIG.HYP3E.debugMessages) { console.log(`Hit! Attack roll ${atkRoll.total} is greater than or equal to [20 - ${targetAc} => ] ${tn}.`) }
       label += `<br /><b>Hits AC ${eval(20 - atkRoll.total)}!</b>`
@@ -577,11 +587,8 @@ export class Hyp3eActor extends Actor {
       }
     }
 
-    let critMissHTML = (game.settings.get(game.system.id, "critMiss") && item && naturalRoll == 1) ? 
-      "<div class='critical-miss'><h4>Xathoqqua’s Woe:</h4></div>" :
-      "";
     // Construct a custom chat card for the attack & damage
-    const attackChat = this.renderCustomChat(atkRoll, debugAtkRollFormula, "", damageChat, critMissHTML);
+    const attackChat = this.renderCustomChat(atkRoll, debugAtkRollFormula, "", damageChat, critFooterHTML);
     // if (CONFIG.HYP3E.debugMessages) { console.log("Attack chat: ", attackChat) }
 
     // Output roll result to a chat message

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -855,7 +855,8 @@ export class Hyp3eActor extends Actor {
                 </div>
               </section>
             </div>
-            <h4 class="dice-formula"><span class="dice-damage">${dmgRoll.total} HP damage!</span></h4>
+            <h4 class="dice-formula"><span class="dice-damage">${dmgRoll.total} HP damage!</span>
+            <span class="damage-button" data-total="${dmgRoll.total}"></span></h4>
           </div>                
         </div>
         <!--

--- a/module/helpers/chat.mjs
+++ b/module/helpers/chat.mjs
@@ -7,6 +7,7 @@ export const addChatMessageButtons = async function(_msg, html, _data) {
     if (dmg.length > 0) {
         dmg.each((_i, b) => {
             let total = Number($(b).data('total'));
+            let naturalRoll = Number($(b).data('natural'));
             const fullDamageButton = $(
                 `<button class="dice-total-fullDamage-btn chat-button-small"><i class="fas fa-user-minus" title="Click to apply full damage to selected token(s)."></i></button>`
             );
@@ -54,7 +55,7 @@ export const addChatMessageButtons = async function(_msg, html, _data) {
                   buttons: {
                     yes: {
                       icon: "<i class='fas fa-check'></i>",
-                      label: `Apply Modifier`,
+                      label: `Apply Modifier Above`,
                       callback: (html) => {
                         const form = html[0].querySelector("form");
                         const modifier = ((
@@ -72,13 +73,13 @@ export const addChatMessageButtons = async function(_msg, html, _data) {
                     },
                     two: {
                         icon: "<i class='fas fa-check'></i>",
-                        label: `2x Damage`,
-                        callback: () => applyHealthDrop(total * 2)
+                        label: `2x Damage (roll only)`,
+                        callback: () => applyHealthDrop(total * 2 + naturalRoll)
                     },
                     three: {
                       icon: "<i class='fas fa-check'></i>",
-                      label: `3x Damage`,
-                      callback: () => applyHealthDrop(total * 3)
+                      label: `3x Damage (roll only)`,
+                      callback: () => applyHealthDrop(total * 3 + (naturalRoll * 2))
                     }
                   },
                   default: "yes",
@@ -201,9 +202,11 @@ async function applyHealthDrop(total) {
         if (damage_mod == 0) continue;
 
         // find updated health
-        const newHealth = oldHealth - damage_mod;
+        let newHealth = oldHealth - damage_mod;
         if (newHealth <  actor.system.hp.min) {
             newHealth = actor.system.hp.min;
+        } else if (newHealth > actor.system.hp.max) {
+            newHealth = actor.system.hp.max;
         }
         await actor.update({ "system.hp.value": newHealth });
 

--- a/module/helpers/chat.mjs
+++ b/module/helpers/chat.mjs
@@ -74,12 +74,12 @@ export const addChatMessageButtons = async function(_msg, html, _data) {
                     two: {
                         icon: "<i class='fas fa-check'></i>",
                         label: `2x Damage (roll only)`,
-                        callback: () => applyHealthDrop(total * 2 + naturalRoll)
+                        callback: () => applyHealthDrop(total + naturalRoll)
                     },
                     three: {
                       icon: "<i class='fas fa-check'></i>",
                       label: `3x Damage (roll only)`,
-                      callback: () => applyHealthDrop(total * 3 + (naturalRoll * 2))
+                      callback: () => applyHealthDrop(total + (naturalRoll * 2))
                     }
                   },
                   default: "yes",

--- a/module/helpers/chat.mjs
+++ b/module/helpers/chat.mjs
@@ -117,7 +117,7 @@ async function applyHealthDrop(total) {
     for (const t of tokens) {
         const actor = t.actor;
         let isDefeated = false;
-        let isUnconsious = false;
+        let isUnconscious = false;
         //Update Health
         const oldHealth = actor.system.hp.value;
         // consider dr
@@ -150,32 +150,32 @@ async function applyHealthDrop(total) {
             if (actor.type == "character") {
                 if (newHealth <= 10) {
                     isDefeated = true;
-                    isUnconsious = false;
+                    isUnconscious = false;
                 } else {
-                    //TODO (wsAI) split defeated and isUnconsious
+                    //TODO (wsAI) split defeated and isUnconscious
                     isDefeated = true;
-                    isUnconsious = true;
+                    isUnconscious = true;
                 }
             } else if (actor.type == "npc") {
                 isDefeated = true;
-                isUnconsious = false;
+                isUnconscious = false;
             }
         } else if (oldHealth <= 0) {
         // token was at <=0 and now is not
             isDefeated = false;
-            isUnconsious = false;
+            isUnconscious = false;
         } else {
         // we can return no status to update
             continue;
         }
-        await t.combatant?.update({ defeated: isDefeated, unconsious: isUnconsious });
+        await t.combatant?.update({ defeated: isDefeated, unconscious: isUnconscious });
         const defeated_status = CONFIG.statusEffects.find(
             (e) => e.id === CONFIG.specialStatusEffects.DEFEATED
         );
-        const unconsious_status = CONFIG.statusEffects.find(
-            (e) => e.id === CONFIG.specialStatusEffects.UNCONSIOUS
+        const unconscious_status = CONFIG.statusEffects.find(
+            (e) => e.id === CONFIG.specialStatusEffects.UNconscious
         );
-        if (!defeated_status && !isUnconsious) continue;
+        if (!defeated_status && !isUnconscious) continue;
         let effect = actor && defeated_status ? defeated_status : CONFIG.controlIcons.defeated;
         if (t.object) {
             await t.object.toggleEffect(effect, {
@@ -189,16 +189,16 @@ async function applyHealthDrop(total) {
             });
         }
         // TODO(wsAI) figure out how to show effect properly
-        // effect = actor && defeated_status ? defeated_status : CONFIG.controlIcons.unconsious;
+        // effect = actor && defeated_status ? defeated_status : CONFIG.controlIcons.unconscious;
         // if (t.object) {
         //     await t.object.toggleEffect(effect, {
         //         overlay: true,
-        //         active: isUnconsious,
+        //         active: isUnconscious,
         //     });
         // } else {
         //     await t.toggleEffect(effect, {
         //         overlay: true,
-        //         active: isUnconsious,
+        //         active: isUnconscious,
         //     });
         // }
     }

--- a/module/helpers/chat.mjs
+++ b/module/helpers/chat.mjs
@@ -54,24 +54,34 @@ export const addChatMessageButtons = async function(_msg, html, _data) {
                   buttons: {
                     yes: {
                       icon: "<i class='fas fa-check'></i>",
-                      label: `Apply`,
-                    },
-                  },
-                  default: "yes",
-                  close: (html) => {
-                    const form = html[0].querySelector("form");
-                    const modifier = ((
-                      form.querySelector('[name="inputField"]')
-                    ))?.value;
-                    if (modifier && modifier != "") {
-                      const nModifier = Number(modifier);
-                      if (nModifier) {
-                        applyHealthDrop(total + nModifier);
-                      } else {
-                        ui.notifications?.error(modifier + " is not a number");
+                      label: `Apply Modifier`,
+                      callback: (html) => {
+                        const form = html[0].querySelector("form");
+                        const modifier = ((
+                          form.querySelector('[name="inputField"]')
+                        ))?.value;
+                        if (modifier && modifier != "") {
+                          const nModifier = Number(modifier);
+                          if (nModifier) {
+                            applyHealthDrop(total + nModifier);
+                          } else {
+                            ui.notifications?.error(modifier + " is not a number");
+                          }
+                        }
                       }
+                    },
+                    two: {
+                        icon: "<i class='fas fa-check'></i>",
+                        label: `2x Damage`,
+                        callback: () => applyHealthDrop(total * 2)
+                    },
+                    three: {
+                      icon: "<i class='fas fa-check'></i>",
+                      label: `3x Damage`,
+                      callback: () => applyHealthDrop(total * 3)
                     }
                   },
+                  default: "yes",
                 }).render(true);
               });
 

--- a/module/helpers/chat.mjs
+++ b/module/helpers/chat.mjs
@@ -1,0 +1,226 @@
+import { HYP3E } from "./config.mjs"
+
+// hook listener for adding buttons to damage roll
+// done here instead of inline to add listeners in js
+export const addChatMessageButtons = async function(_msg, html, _data) {
+    let dmg = html.find(".damage-button");
+    if (dmg.length > 0) {
+        dmg.each((i, b) => {
+            let total = Number($(b).data('total'));
+            const fullDamageButton = $(
+                `<button class="dice-total-fullDamage-btn chat-button-small"><i class="fas fa-user-minus" title="Click to apply full damage to selected token(s)."></i></button>`
+            );
+            const halfDamageButton = $(
+                `<button class="dice-total-halfDamage-btn chat-button-small"><i class="fas fa-user-shield" title="Click to apply half damage to selected token(s)."></i></button>`
+            );
+            const fullHealingButton = $(
+                `<button class="dice-total-fullHealing-btn chat-button-small"><i class="fas fa-user-plus" title="Click to apply full healing to selected token(s)."></i></button>`
+            );        
+            const fullDamageModifiedButton = $(
+                `<button class="dice-total-fullDamageMod-btn chat-button-small"><i class="fas fa-user-edit" title="Click to apply full damage with modifier prompt to selected token(s)."></i></button>`
+            );
+            dmg.append(fullDamageButton);
+            dmg.append(halfDamageButton);
+            dmg.append(fullHealingButton);
+            dmg.append(fullDamageModifiedButton);
+
+            // Handle button clicks
+            fullDamageButton.on("click", (ev) => {
+                ev.stopPropagation();
+                applyHealthDrop(total);
+            });
+
+            halfDamageButton.on("click", (ev) => {
+                ev.stopPropagation();
+                applyHealthDrop(Math.floor(total*0.5));
+            });
+
+            fullHealingButton.on("click", (ev) => {
+                ev.stopPropagation();
+                applyHealthDrop(total*-1);
+            });
+
+            fullDamageModifiedButton.on("click", (ev) => {
+                ev.stopPropagation();
+                new Dialog({
+                  title: "Apply Modifier to Damage",
+                  content: `
+                      <form>
+                        <div class="form-group">
+                          <label>Modifier to damage (${total}) </label>
+                          <input type='text' name='inputField'></input>
+                        </div>
+                      </form>`,
+                  buttons: {
+                    yes: {
+                      icon: "<i class='fas fa-check'></i>",
+                      label: `Apply`,
+                    },
+                  },
+                  default: "yes",
+                  close: (html) => {
+                    const form = html[0].querySelector("form");
+                    const modifier = ((
+                      form.querySelector('[name="inputField"]')
+                    ))?.value;
+                    if (modifier && modifier != "") {
+                      const nModifier = Number(modifier);
+                      if (nModifier) {
+                        applyHealthDrop(total + nModifier);
+                      } else {
+                        ui.notifications?.error(modifier + " is not a number");
+                      }
+                    }
+                  },
+                }).render(true);
+              });
+
+        });
+    }
+}
+
+// Show a change in value by a token
+export async function showValueChange(t, fillColor,total) {
+    const floaterData = {
+      anchor: CONST.TEXT_ANCHOR_POINTS.CENTER,
+      direction:
+        total > 0
+          ? CONST.TEXT_ANCHOR_POINTS.BOTTOM
+          : CONST.TEXT_ANCHOR_POINTS.TOP,
+      // duration: 2000,
+      fontSize: 32,
+      fill: fillColor,
+      stroke: 0x000000,
+      strokeThickness: 4,
+      jitter: 0.3,
+    };
+  
+    canvas?.interface?.createScrollingText(
+        t.center,
+        `${total * -1}`,
+        floaterData
+    );
+  }
+  
+// Apply a health drop (positive number is damage) to one or more tokens.
+async function applyHealthDrop(total) {
+    if (total == 0) return; // Skip changes of 0
+    const tokens = canvas?.tokens?.controlled;
+
+    if (!tokens || tokens.length == 0) {
+        ui.notifications?.error("Please select at least one token");
+        return;
+    }
+
+    const names = [];
+    
+    for (const t of tokens) {
+        const actor = t.actor;
+        let isDefeated = false;
+        let isUnconsious = false;
+        //Update Health
+        const oldHealth = actor.system.hp.value;
+        // consider dr
+        let damage_mod = total;
+        // If applying damage check dr
+        if (total > 0 && actor.system.ac.dr > 0) {
+            damage_mod = Math.max(0, total - actor.system.ac.dr);
+            names.push(`${t.name} (dr ${actor.system.ac.dr} applied)`)
+        } else {
+            names.push(t.name);
+        }
+        
+        if (damage_mod == 0) continue;
+
+        // find updated health
+        const newHealth = oldHealth - damage_mod;
+        if (newHealth <  actor.system.hp.min) {
+            newHealth = actor.system.hp.min;
+        }
+        await actor.update({ "system.hp.value": newHealth });
+
+        // Show the health change by the token
+        // Taken from Mana
+        //https://gitlab.com/mkahvi/fvtt-micro-modules/-/blob/master/pf1-floating-health/floating-health.mjs#L182-194
+        const fillColor = damage_mod < 0 ? "0x00FF00" : "0xFF0000";
+        showValueChange(t, fillColor, damage_mod);
+
+        // Change token status 
+        if (newHealth <= 0) {
+            if (actor.type == "character") {
+                if (newHealth <= 10) {
+                    isDefeated = true;
+                    isUnconsious = false;
+                } else {
+                    //TODO (wsAI) split defeated and isUnconsious
+                    isDefeated = true;
+                    isUnconsious = true;
+                }
+            } else if (actor.type == "npc") {
+                isDefeated = true;
+                isUnconsious = false;
+            }
+        } else if (oldHealth <= 0) {
+        // token was at <=0 and now is not
+            isDefeated = false;
+            isUnconsious = false;
+        } else {
+        // we can return no status to update
+            continue;
+        }
+        await t.combatant?.update({ defeated: isDefeated, unconsious: isUnconsious });
+        const defeated_status = CONFIG.statusEffects.find(
+            (e) => e.id === CONFIG.specialStatusEffects.DEFEATED
+        );
+        const unconsious_status = CONFIG.statusEffects.find(
+            (e) => e.id === CONFIG.specialStatusEffects.UNCONSIOUS
+        );
+        if (!defeated_status && !isUnconsious) continue;
+        let effect = actor && defeated_status ? defeated_status : CONFIG.controlIcons.defeated;
+        if (t.object) {
+            await t.object.toggleEffect(effect, {
+                overlay: true,
+                active: isDefeated,
+            });
+        } else {
+            await t.toggleEffect(effect, {
+                overlay: true,
+                active: isDefeated,
+            });
+        }
+        // TODO(wsAI) figure out how to show effect properly
+        // effect = actor && defeated_status ? defeated_status : CONFIG.controlIcons.unconsious;
+        // if (t.object) {
+        //     await t.object.toggleEffect(effect, {
+        //         overlay: true,
+        //         active: isUnconsious,
+        //     });
+        // } else {
+        //     await t.toggleEffect(effect, {
+        //         overlay: true,
+        //         active: isUnconsious,
+        //     });
+        // }
+    }
+    // Log health hit as a chat message
+    const title = total > 0
+        ? `Applied ${total} damage`
+        : `Applied ${total*-1} healing`;
+    const templateData = {
+        title: title,
+        body: `<ul><li>${names
+            // .map((t) => t.name)
+            .join("</li><li>")}</li></ul>`,
+        // image: image
+    };
+
+    const template = `${HYP3E.systemRoot}/templates/chat/apply-damage.hbs`;
+    const html = await renderTemplate(template, templateData);
+
+    const chatData = {
+        user: game.user_id,
+        content: html
+    };
+
+    ChatMessage.create(chatData, {});
+}

--- a/module/hyp3e.mjs
+++ b/module/hyp3e.mjs
@@ -99,6 +99,28 @@ Hooks.once('init', async function() {
     requiresReload: true,
   });
 
+  // Critical hit 
+  game.settings.register(game.system.id, "critHits", {
+    name: game.i18n.localize("HYP3E.settings.critHits"),
+    hint: game.i18n.localize("HYP3E.settings.critHitsHint"),
+    default: true,
+    scope: "world",
+    type: Boolean,
+    config: true,
+    requiresReload: true,
+  });
+  
+  // Critical Miss 
+  game.settings.register(game.system.id, "critMiss", {
+    name: game.i18n.localize("HYP3E.settings.critMiss"),
+    hint: game.i18n.localize("HYP3E.settings.critMissHint"),
+    default: true,
+    scope: "world",
+    type: Boolean,
+    config: true,
+    requiresReload: true,
+  });
+    
   // If we ever need migration scripts, use this version number for comparison
   console.log("System info:", game.system)
 
@@ -186,6 +208,9 @@ Hooks.once("ready", async function() {
   const flipRollUnderMods = game.settings.get(game.system.id, "flipRollUnderMods");
   CONFIG.HYP3E.flipRollUnderMods = flipRollUnderMods;
   if (CONFIG.HYP3E.debugMessages) { console.log("CONFIG Reverse situational modifiers on roll-under checks:", CONFIG.HYP3E.flipRollUnderMods) }
+
+  // Set crit configs
+  //const critHits = game.settings.get(game.system.id, "critHits");
 
   // Load races list
   const races = game.settings.get(game.system.id, "races");

--- a/module/hyp3e.mjs
+++ b/module/hyp3e.mjs
@@ -100,7 +100,7 @@ Hooks.once('init', async function() {
   });
 
   // Critical hit 
-  game.settings.register(game.system.id, "critHits", {
+  game.settings.register(game.system.id, "critHit", {
     name: game.i18n.localize("HYP3E.settings.critHits"),
     hint: game.i18n.localize("HYP3E.settings.critHitsHint"),
     default: true,

--- a/module/hyp3e.mjs
+++ b/module/hyp3e.mjs
@@ -7,6 +7,7 @@ import { Hyp3eItemSheet } from "./sheets/item-sheet.mjs";
 // Import helper/utility classes and constants.
 import { preloadHandlebarsTemplates } from "./helpers/templates.mjs";
 import { HYP3E } from "./helpers/config.mjs";
+import { addChatMessageButtons } from "./helpers/chat.mjs";
 
 /* -------------------------------------------- */
 /*  Init Hook                                   */
@@ -265,6 +266,8 @@ Hooks.once("ready", async function() {
   }
 
 });
+
+Hooks.on("renderChatMessage", addChatMessageButtons);
 
 /* -------------------------------------------- */
 /*  Migrate system/world functions              */

--- a/templates/chat/apply-damage.hbs
+++ b/templates/chat/apply-damage.hbs
@@ -1,11 +1,4 @@
-<section class="hyp3e chat-message">
-    <div class="hyp3e chat-block">
-        <div class="flexrow chat-header">
-            <div class="chat-title">
-                <h2>{{title}}</h2>
-            </div>
-            {{!-- <div class="chat-img" style="background-image:url({{image}})"></div> --}}
-        </div>
-        <div class="chat-details">{{{body}}}</div>
-    </div>
-</section>
+<div class="message-content">
+    <h4>{{title}}</h4>
+    <div class="chat-details">{{{body}}}</div>
+</div>

--- a/templates/chat/apply-damage.hbs
+++ b/templates/chat/apply-damage.hbs
@@ -1,0 +1,11 @@
+<section class="hyp3e chat-message">
+    <div class="hyp3e chat-block">
+        <div class="flexrow chat-header">
+            <div class="chat-title">
+                <h2>{{title}}</h2>
+            </div>
+            {{!-- <div class="chat-img" style="background-image:url({{image}})"></div> --}}
+        </div>
+        <div class="chat-details">{{{body}}}</div>
+    </div>
+</section>

--- a/templates/chat/crit-roll.hbs
+++ b/templates/chat/crit-roll.hbs
@@ -1,0 +1,10 @@
+<div class="message-content">
+    <h4 class="dice-damage"> {{title}}</h4>
+
+  <div class="dice-roll">
+    {{{diceRoll}}}
+  </div>
+  <div>
+    {{{ content }}}
+  </div>
+</div>


### PR DESCRIPTION

A span/div with a class .damage-button and data-total property set will have buttons appended to the element. The 4 buttons: apply full, apply 1/2, apply as healing (useful for hitting the wrong token damage), and apply with modifier.  There are mouse over hints (titles) on those.  When damage (or healing) is applied it will show the change by the token (green up for healing, red and down for damage) and if the HP < 0 the token takes the dead effect. Want to split that up for PCs for unconscious vs dead. 

DR is respected for applying damage.

 - Spell damage is not supported currently as it rolls damage differently (just would need damage listen in a special html span/div)
  - Right click context menu for apply damage is not supported (this should be easy to do)

Let me know what you want changed.