### PR TITLE
Rework critical hit/miss chat handling

### DIFF
--- a/module/chat/handlers/crit-handlers.mjs
+++ b/module/chat/handlers/crit-handlers.mjs
@@ -6,7 +6,7 @@
  */
 import { HYP3E } from "../../helpers/config.mjs"
 import { Hyp3eLogger } from "../../helpers/logger.mjs";
-import { applyHealthChange } from "./damage-handlers.mjs";
+import { applyHealthChange, rollDmgButton } from "./damage-handlers.mjs";
 
 /**
  * 
@@ -63,6 +63,22 @@ export async function handleCritMissOrHitButtons(html) {
                 baseClassLabel = "NPC"
             }
             let actorId = $(b).data('actorId');
+
+            // Read weapon damage data embedded by actor.mjs (present when item has a valid damage formula)
+            const formula = $(b).data('formula');
+            const dmgData = formula ? {
+                formula:      formula,
+                debugFormula: $(b).data('debugFormula'),
+                baseDamage:   $(b).data('baseDamage'),
+                damageType:   $(b).data('damageType'),
+                itemId:       $(b).data('itemId'),
+                itemUuid:     $(b).data('itemUuid'),
+                actorId:      actorId,
+                tokenId:      $(b).data('tokenId'),
+                sourceType:   $(b).data('sourceType'),
+                damageGroups: $(b).data('damageGroups'),
+            } : null;
+
             const icon = "fa-user-slash";
             const critMissButton = $(long_button('miss',`Roll Critical Miss for ${baseClassLabel}-class`, icon));
             critMissElement.append(critMissButton);
@@ -70,7 +86,7 @@ export async function handleCritMissOrHitButtons(html) {
             // Handle button clicks
             critMissButton.on("click", (ev) => {
                 ev.stopPropagation();
-                rollCritMiss(baseClass, actorId);
+                rollCritMiss(baseClass, actorId, dmgData);
             });
         });
     }
@@ -85,14 +101,68 @@ export async function handleCritMissOrHitButtons(html) {
             }
             let actorId = $(b).data('actorId');
             const icon = "fa-user";
-            const critHitButton = $(long_button('hit',`Roll Critical Hit for ${baseClassLabel}-class`, icon));
-            critHitElement.append(critHitButton);
 
-            // Handle button clicks
-            critHitButton.on("click", (ev) => {
-                ev.stopPropagation();
-                rollCritHit(baseClass, actorId);
-            });
+            // Check if the message also has a damage roll button to combine with
+            const dmgEl = html.find(".dmg-roll-button");
+            if (dmgEl.length > 0) {
+                const dmg2hEl = html.find(".dmg-roll-button2h");
+                const dmgData = {
+                    formula:      dmgEl.data('formula'),
+                    debugFormula: dmgEl.data('debugFormula'),
+                    baseDamage:   dmgEl.data('baseDamage'),
+                    damageType:   dmgEl.data('damageType'),
+                    itemId:       dmgEl.data('itemId'),
+                    itemUuid:     dmgEl.data('itemUuid'),
+                    actorId:      dmgEl.data('actorId'),
+                    tokenId:      dmgEl.data('tokenId'),
+                    sourceType:   dmgEl.data('sourceType'),
+                    damageGroups: dmgEl.data('damageGroups'),
+                };
+
+                // Hide separate damage button(s) — the combined button covers them
+                dmgEl.hide();
+                if (dmg2hEl.length > 0) dmg2hEl.hide();
+
+                const critDmgButton = $(long_button('hit', `Roll Critical Hit Damage for ${baseClassLabel}-class`, icon));
+                critHitElement.append(critDmgButton);
+                critDmgButton.on("click", (ev) => {
+                    ev.stopPropagation();
+                    rollCritHitWithDamage(baseClass, dmgData.actorId, dmgData.formula, dmgData.debugFormula,
+                        dmgData.baseDamage, dmgData.damageType, dmgData.itemId, dmgData.itemUuid,
+                        dmgData.tokenId, dmgData.sourceType, dmgData.damageGroups);
+                });
+
+                if (dmg2hEl.length > 0) {
+                    const dmgData2h = {
+                        formula:      dmg2hEl.data('formula'),
+                        debugFormula: dmg2hEl.data('debugFormula'),
+                        baseDamage:   dmg2hEl.data('baseDamage'),
+                        damageType:   dmg2hEl.data('damageType'),
+                        itemId:       dmg2hEl.data('itemId'),
+                        itemUuid:     dmg2hEl.data('itemUuid'),
+                        actorId:      dmg2hEl.data('actorId'),
+                        tokenId:      dmg2hEl.data('tokenId'),
+                        sourceType:   dmg2hEl.data('sourceType'),
+                        damageGroups: dmg2hEl.data('damageGroups'),
+                    };
+                    const crit2hDmgButton = $(long_button('hit', `Roll Critical Hit 2H Damage for ${baseClassLabel}-class`, icon));
+                    critHitElement.append(crit2hDmgButton);
+                    crit2hDmgButton.on("click", (ev) => {
+                        ev.stopPropagation();
+                        rollCritHitWithDamage(baseClass, dmgData2h.actorId, dmgData2h.formula, dmgData2h.debugFormula,
+                            dmgData2h.baseDamage, dmgData2h.damageType, dmgData2h.itemId, dmgData2h.itemUuid,
+                            dmgData2h.tokenId, dmgData2h.sourceType, dmgData2h.damageGroups);
+                    });
+                }
+            } else {
+                // No damage button present (e.g. crit-miss hitAllyCrit case) — show text result only
+                const critHitButton = $(long_button('hit', `Roll Critical Hit for ${baseClassLabel}-class`, icon));
+                critHitElement.append(critHitButton);
+                critHitButton.on("click", (ev) => {
+                    ev.stopPropagation();
+                    rollCritHit(baseClass, actorId);
+                });
+            }
         });
     }
 
@@ -166,8 +236,10 @@ async function rollCritHit(charType, actorId) {
     })
 }
 
-async function rollCritMiss(charType, actorId) {
+async function rollCritMiss(charType, actorId, dmgData = null) {
     let content = "";
+    let hitCrit = false;
+    let hitAllyOrSelf = false;
     let roll = await new Roll("1d12").roll();
     if (roll.total <= 2) {
         content = game.i18n.localize("HYP3E.attack.critMiss.badMiss");
@@ -177,7 +249,7 @@ async function rollCritMiss(charType, actorId) {
         } else if (roll.total <= 8) {
             const [feet, direction] = await getFeetAndDirectionCritMiss();
             content = game.i18n.format(
-                "HYP3E.attack.critMiss.dropWeapon", 
+                "HYP3E.attack.critMiss.dropWeapon",
                 { feet: feet, direction: direction }
             );
         } else if (roll.total <= 9) {
@@ -185,14 +257,18 @@ async function rollCritMiss(charType, actorId) {
         } else if (roll.total <= 10) {
             content = game.i18n.localize("HYP3E.attack.critMiss.tripFall");
         } else if (roll.total <= 11) {
+            hitAllyOrSelf = true;
             if (await getCritMissHitCrit(charType)) {
                 content = game.i18n.localize("HYP3E.attack.critMiss.hitAllyCrit");
+                hitCrit = true;
             } else {
                 content = game.i18n.localize("HYP3E.attack.critMiss.hitAlly");
-            }            
+            }
         } else if (roll.total == 12) {
+            hitAllyOrSelf = true;
             if (await getCritMissHitCrit(charType)) {
                 content = game.i18n.localize("HYP3E.attack.critMiss.hitSelfCrit");
+                hitCrit = true;
             } else {
                 content = game.i18n.localize("HYP3E.attack.critMiss.hitSelf");
             }
@@ -205,7 +281,7 @@ async function rollCritMiss(charType, actorId) {
         } else if (roll.total <= 4) {
             const [feet, direction] = await getFeetAndDirectionCritMiss();
             content = game.i18n.format(
-                "HYP3E.attack.critMiss.dropWeapon", 
+                "HYP3E.attack.critMiss.dropWeapon",
                 { feet: feet, direction: direction }
             );
         } else if (roll.total <= 6) {
@@ -213,14 +289,18 @@ async function rollCritMiss(charType, actorId) {
         } else if (roll.total <= 8) {
             content = game.i18n.localize("HYP3E.attack.critMiss.tripFall");
         } else if (roll.total <= 10) {
+            hitAllyOrSelf = true;
             if (await getCritMissHitCrit(charType)) {
                 content = game.i18n.localize("HYP3E.attack.critMiss.hitAllyCrit");
+                hitCrit = true;
             } else {
                 content = game.i18n.localize("HYP3E.attack.critMiss.hitAlly");
-            }            
+            }
         } else if (roll.total <= 12) {
+            hitAllyOrSelf = true;
             if (await getCritMissHitCrit(charType)) {
                 content = game.i18n.localize("HYP3E.attack.critMiss.hitSelfCrit");
+                hitCrit = true;
             } else {
                 content = game.i18n.localize("HYP3E.attack.critMiss.hitSelf");
             }
@@ -234,7 +314,7 @@ async function rollCritMiss(charType, actorId) {
         } else if (roll.total <= 6) {
             const [feet, direction] = await getFeetAndDirectionCritMiss();
             content = game.i18n.format(
-                "HYP3E.attack.critMiss.dropWeapon", 
+                "HYP3E.attack.critMiss.dropWeapon",
                 { feet: feet, direction: direction }
             );
         } else if (roll.total <= 8) {
@@ -242,14 +322,18 @@ async function rollCritMiss(charType, actorId) {
         } else if (roll.total <= 10) {
             content = game.i18n.localize("HYP3E.attack.critMiss.tripFall");
         } else if (roll.total <= 11) {
-            if (getCritMissHitCrit(charType)) {
+            hitAllyOrSelf = true;
+            if (await getCritMissHitCrit(charType)) {
                 content = game.i18n.localize("HYP3E.attack.critMiss.hitAllyCrit");
+                hitCrit = true;
             } else {
                 content = game.i18n.localize("HYP3E.attack.critMiss.hitAlly");
-            }            
+            }
         } else if (roll.total <= 12) {
-            if (getCritMissHitCrit(charType)) {
+            hitAllyOrSelf = true;
+            if (await getCritMissHitCrit(charType)) {
                 content = game.i18n.localize("HYP3E.attack.critMiss.hitSelfCrit");
+                hitCrit = true;
             } else {
                 content = game.i18n.localize("HYP3E.attack.critMiss.hitSelf");
             }
@@ -259,6 +343,25 @@ async function rollCritMiss(charType, actorId) {
     }
 
     content = `<div class="dice-damage">` + content + `</div>`
+    if (hitAllyOrSelf && dmgData) {
+        // Inject a damage roll button so the player can roll damage for the accidental hit.
+        // For hitAllyCrit/hitSelfCrit, the .critical-hit div below will cause the chat handler
+        // to replace this with a combined "Roll Critical Hit Damage" button automatically.
+        content += `<div class='dmg-roll-button' style='padding-top: 5px'` +
+            ` data-item-id='${dmgData.itemId}'` +
+            ` data-item-uuid='${dmgData.itemUuid}'` +
+            ` data-actor-id='${dmgData.actorId}'` +
+            ` data-token-id='${dmgData.tokenId}'` +
+            ` data-base-damage='${dmgData.baseDamage}'` +
+            ` data-damage-type='${dmgData.damageType}'` +
+            ` data-formula='${dmgData.formula}'` +
+            ` data-debug-formula='${dmgData.debugFormula}'` +
+            ` data-damage-groups='${JSON.stringify(dmgData.damageGroups)}'` +
+            ` data-source-type='${dmgData.sourceType}'></div>`;
+    }
+    if (hitCrit) {
+        content += `<div class='critical-hit' data-base-class='${charType}' data-actor-id='${actorId}'></div>`;
+    }
     const templateData = {
         // title: game.i18n.localize(`HYP3E.attack.critMiss.${charType}`),
         title: "",
@@ -283,6 +386,67 @@ async function rollCritMiss(charType, actorId) {
         flavor: flavor,
         content: html
     })
+}
+
+/**
+ * Roll 1d6 to determine the critical hit multiplier for a given class, then roll
+ * and send damage with that multiplier applied — combining the two separate steps
+ * into a single button click.
+ */
+async function rollCritHitWithDamage(charType, actorId, formula, debugDmgRollFormula, baseDmgFormula, damageType, itemId, itemUuid, tokenId, sourceType, damageGroups) {
+    const dmg = game.i18n.localize("HYP3E.headers.damage");
+    let roll = await new Roll("1d6").roll();
+    let critLabel, formulaAppend;
+
+    if (charType === "fighter") {
+        if (roll.total <= 2) {
+            critLabel = `+2 ${dmg}`;
+            formulaAppend = "+2";
+        } else if (roll.total <= 4) {
+            critLabel = `×2 Dice ${dmg}`;
+            formulaAppend = `+${baseDmgFormula}`;
+        } else {
+            critLabel = `×3 Dice ${dmg}`;
+            formulaAppend = `+${baseDmgFormula}+${baseDmgFormula}`;
+        }
+    } else if (charType === "magician") {
+        if (roll.total <= 2) {
+            critLabel = `+1 ${dmg}`;
+            formulaAppend = "+1";
+        } else if (roll.total <= 4) {
+            critLabel = `+2 ${dmg}`;
+            formulaAppend = "+2";
+        } else {
+            critLabel = `×2 Dice ${dmg}`;
+            formulaAppend = `+${baseDmgFormula}`;
+        }
+    } else {
+        // cleric / thief / npc-monster
+        if (roll.total <= 1) {
+            critLabel = `+1 ${dmg}`;
+            formulaAppend = "+1";
+        } else if (roll.total <= 3) {
+            critLabel = `+2 ${dmg}`;
+            formulaAppend = "+2";
+        } else if (roll.total <= 5) {
+            critLabel = `×2 Dice ${dmg}`;
+            formulaAppend = `+${baseDmgFormula}`;
+        } else {
+            critLabel = `×3 Dice ${dmg}`;
+            formulaAppend = `+${baseDmgFormula}+${baseDmgFormula}`;
+        }
+    }
+
+    const baseClassLabel = charType === "npc" ? "NPC" : charType.charAt(0).toUpperCase() + charType.substring(1);
+    const title = `${baseClassLabel} Critical Hit: ${critLabel}`;
+    const adjustedFormula = formula + formulaAppend;
+
+    await rollDmgButton(
+        adjustedFormula, debugDmgRollFormula, baseDmgFormula, damageType,
+        actorId, itemId, itemUuid, tokenId, sourceType,
+        damageGroups,
+        title
+    );
 }
 
 /**********************************************************

--- a/module/chat/handlers/damage-handlers.mjs
+++ b/module/chat/handlers/damage-handlers.mjs
@@ -232,7 +232,7 @@ export async function handleGenericDamageHealButtons(_msg, html) {
  * @param {*} sourceType - Item type, either "weapon" or "spell"
  * @returns null
  */
-async function rollDmgButton(formula, debugDmgRollFormula, baseDmgFormula, damageType, actorId, itemId, itemUuid, tokenId, sourceType, damageGroups) {
+export async function rollDmgButton(formula, debugDmgRollFormula, baseDmgFormula, damageType, actorId, itemId, itemUuid, tokenId, sourceType, damageGroups, titleOverride = null) {
   // Fix invalid formulae if possible
   if (formula == "" || formula == null || formula == "0") {
     formula = "0d0"
@@ -367,7 +367,7 @@ async function rollDmgButton(formula, debugDmgRollFormula, baseDmgFormula, damag
   }
 
   const damageText = damageType.toLowerCase().includes("heal") ? "Healing" : "Damage"
-  const title = `Rolling ${damageText}...`
+  const title = titleOverride ?? `Rolling ${damageText}...`
   const templateData = {
     title: title,
     dmgRoll: dmgRoll,

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -2500,23 +2500,37 @@ export class Hyp3eActor extends Actor {
       );
       atkRoll.hit = hit; // Attach hit status to the roll object
 
-      // Prepare Damage Formula (if hit)
+      // Prepare Damage Formula (if hit, or on crit miss so damage data is available for hitAlly/hitSelf outcomes)
       let damageFormulas = {};
-      if (hit && item && Roll.validate(itemData.damage)) {
+      const isCritMiss = naturalRoll === 1 && CONFIG.HYP3E.critMiss;
+      if ((hit || isCritMiss) && item && Roll.validate(itemData.damage)) {
           damageFormulas = this._prepareDamageFormulas(itemData, ammoMods, actorData);
-          // Temporarily attach to item object for chat card context
-          // item.dmgFormula = damageFormulas.primary?.formula;
-          // item.debugDmgRollFormula = damageFormulas.primary?.debugFormula;
-          // item.dmgFormula2h = damageFormulas.secondary?.formula;
-          // item.debugDmgRollFormula2h = damageFormulas.secondary?.debugFormula;
+      }
+
+      // Embed damage data in the crit-miss footer so the crit miss handler can offer damage rolls
+      let resolvedCritFooter = critFooter;
+      if (isCritMiss && damageFormulas.primary) {
+          const df = damageFormulas.primary;
+          resolvedCritFooter = `<div class='critical-miss'` +
+              ` data-base-class='${this.system.baseClass}'` +
+              ` data-actor-id='${this.id}'` +
+              ` data-formula='${df.formula}'` +
+              ` data-debug-formula='${df.debugFormula}'` +
+              ` data-base-damage='${itemData.damage}'` +
+              ` data-damage-type='${itemData.dmgType}'` +
+              ` data-item-id='${item.id}'` +
+              ` data-item-uuid='${item.uuid}'` +
+              ` data-token-id='${attacker?.id ?? ""}'` +
+              ` data-source-type='${item.type}'` +
+              ` data-damage-groups='${JSON.stringify(df.damageGroups)}'></div>`;
       }
 
       // Render chat message
       const chatLabel = this._createChatLabel(this.img, itemName);
       const attackHeader = `${attackTextBase}${dataset.targetName ? ` vs. ${dataset.targetName}` : ''}... ${attackTextResult}`;
 
-      Hyp3eLogger.info("Hyp3eActor rollAttackOrSpell", `Chat data:`, {chatLabel, attackHeader, critFooter});
-      await renderCustomChat(atkRoll, item, damageFormulas, this, attacker?.id, chatLabel, debugAtkRollFormula, attackHeader, critFooter, rollResponse.rollMode);
+      Hyp3eLogger.info("Hyp3eActor rollAttackOrSpell", `Chat data:`, {chatLabel, attackHeader, resolvedCritFooter});
+      await renderCustomChat(atkRoll, item, damageFormulas, this, attacker?.id, chatLabel, debugAtkRollFormula, attackHeader, resolvedCritFooter, rollResponse.rollMode);
 
       // Return Roll Result
       return atkRoll;


### PR DESCRIPTION
- Fix missing await on getCritMissHitCrit() calls in cleric/thief/npc branch, which caused hitAllyCrit/hitSelfCrit to always be selected
- Combine "Roll Damage" and "Roll Critical Hit" into a single button on natural 20 attack messages; the button rolls the 1d6 crit multiplier and the damage in one click, rendering via the standard damage-roll UI
- On crit miss results of hitAlly/hitSelf, inject a damage roll button so the player can roll damage for the accidental hit
- On crit miss results of hitAllyCrit/hitSelfCrit, inject both a damage roll button and a critical-hit div so the combined crit damage button is presented automatically
- Compute weapon damage formulas on a natural 1 (not just on a hit) and embed all damage data in the .critical-miss div so it survives into the crit miss result message
- Export rollDmgButton from damage-handlers and add an optional titleOverride parameter used by the combined crit damage path
- Pass original damageGroups through rollCritHitWithDamage so the crit damage result uses the same per-type icon UI as a regular damage roll

Tested by creating one character for each base class and then rolled attack rolls a rediculous number of times to verify that the behavior was correct and consistent.