### PR TITLE
Fix: Clearing description fields via edit saves properly

### DIFF
--- a/module/sheets/item-sheet-v2.mjs
+++ b/module/sheets/item-sheet-v2.mjs
@@ -296,19 +296,19 @@ export class Hyp3eItemSheetV2 extends HandlebarsApplicationMixin(ItemSheetV2) {
     // const formDataObj = formData.object;
     const formDataObj = foundry.utils.expandObject(formData.object);
     // Not all item types have identification, so default to identified=true
-    const isIdentified = foundry.utils.getProperty(formDataObj, "system.identified") || this.item.system.identified;
+    const isIdentified = foundry.utils.getProperty(formDataObj, "system.identified") ?? this.item.system.identified;
     Hyp3eLogger.info("_processFormData", `Is item identified?`, isIdentified);
 
     // Apply name and description based on identification state.
     if (isIdentified) {
       const realName = foundry.utils.getProperty(formDataObj, "system.realName") || this.item.system.realName;
-      const realDesc = foundry.utils.getProperty(formDataObj, "system.realDescription") || this.item.system.realDescription;
+      const realDesc = foundry.utils.getProperty(formDataObj, "system.realDescription") ?? this.item.system.realDescription;
 
       formDataObj["name"] = realName;
       formDataObj["system.description"] = realDesc;
     } else {
       let aliasName = foundry.utils.getProperty(formDataObj, "system.itemAlias") || this.item.system.itemAlias;
-      const aliasDesc = foundry.utils.getProperty(formDataObj, "system.aliasDescription") || this.item.system.aliasDescription;
+      const aliasDesc = foundry.utils.getProperty(formDataObj, "system.aliasDescription") ?? this.item.system.aliasDescription;
 
       // Ensure aliasName is not empty or just whitespace
       if (!aliasName || aliasName.trim() === "") {

--- a/tests/item-sheet-form-data.test.mjs
+++ b/tests/item-sheet-form-data.test.mjs
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const itemSheetUrl = new URL("../module/sheets/item-sheet-v2.mjs", import.meta.url);
+
+test("item form processing preserves submitted false and empty-string values", async () => {
+  const source = await readFile(itemSheetUrl, "utf8");
+  const submittedFields = [
+    "system.identified",
+    "system.realDescription",
+    "system.aliasDescription"
+  ];
+
+  for (const field of submittedFields) {
+    const assignment = new RegExp(
+      `getProperty\\(formDataObj, "${field.replace(".", "\\.")}"\\)\\s*\\?\\?`
+    );
+    assert.match(source, assignment, `${field} must use a nullish fallback`);
+  }
+});


### PR DESCRIPTION
Quick fix to allow players to delete a rich text description field and save an empty string; previously the empty string was sending null which was causing the description field to revert to the previous values.