### PR TITLE
FIX: Add damage roll capabilities to 'Feature' item types

### DIFF
--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -478,7 +478,7 @@ export class Hyp3eItem extends Item {
   _renderItemProperties(item, itemData, actorData) {
     const parts = [];
 
-    if (item.type === 'feature') parts.push(this._renderFeatureSection(itemData));
+    if (item.type === 'feature') parts.push(this._renderFeatureSection(itemData, item, actorData));
     if (item.type === 'weapon') parts.push(this._renderWeaponSection(itemData, item, actorData));
     if (item.type === 'spell') parts.push(this._renderSpellSection(itemData, item, actorData));
     if (item.type === 'item') parts.push(this._renderItemCheckSection(itemData));
@@ -488,11 +488,13 @@ export class Hyp3eItem extends Item {
     return parts.join("");
   }
 
-  _renderFeatureSection(itemData) {
+  _renderFeatureSection(itemData, item, actorData) {
+    const parts = [];
+    parts.push(this._renderDamageRoll(itemData, item, actorData));
     if (itemData.formula && itemData.tn) {
-      return `<p>Ability Check: ${itemData.formula} equal or under ${itemData.tn}</p>`;
+      parts.push(`<p>Ability Check: ${itemData.formula} equal or under ${itemData.tn}</p>`);
     }
-    return "";
+    return parts.join("");
   }
 
   _renderWeaponSection(itemData, item, actorData) {

--- a/templates/actor/parts/section-npc-items.hbs
+++ b/templates/actor/parts/section-npc-items.hbs
@@ -25,7 +25,14 @@
               <img src="{{item.img}}" title="{{item.name}}" width="24" height="24"/>
             </a>
             {{else}}
+            {{#if item.system.damage}}
+            <a data-action="displayItem"
+                title='{{localize "HYP3E.item.rollDamage"}}'>
+              <img src="{{item.img}}" title="{{item.name}}" width="24" height="24"/>
+            </a>
+            {{else}}
             <img src="{{item.img}}" title="{{item.name}}" width="24" height="24"/>
+            {{/if}}
             {{/if}}
           </div>
           <a data-action="dropItemDescription"><span class="item-drop">{{item.name}}</span></a>
@@ -33,10 +40,17 @@
         <div class="item-prop">{{item.system.formula}}</div>
         <div class="item-prop">{{item.system.tn}}</div>
         <div class="item-controls">
-          <a data-action="displayItem" 
+          {{#if item.system.damage}}
+          <a data-action="displayItem"
+              title='{{localize "HYP3E.item.rollDamage"}}'>
+            <i class="fas fa-droplet"></i>
+          </a>
+          {{else}}
+          <a data-action="displayItem"
               title='{{localize "HYP3E.item.show"}}'>
             <i class="fas fa-eye"></i>
           </a>
+          {{/if}}
           <a data-action="editItem" 
               title="{{localize 'HYP3E.item.edit'}}">
             <i class="fas fa-edit"></i>

--- a/templates/item/parts/sidebar-feature.hbs
+++ b/templates/item/parts/sidebar-feature.hbs
@@ -20,4 +20,16 @@
               {{selectOptions saveThrows selected=system.save localize=true}}
             </select>
           </div>
+          <label for="system.damage" class="resource-label">{{localize 'HYP3E.headers.damage'}}</label>
+          <a class="item-button item-control"
+              aria-label="{{localize 'HYP3E.headers.damageTypes'}}"
+              role="button"
+              data-tooltip="HYP3E.headers.damageTypes"
+              data-action="setDmgTypes">
+            <i class="fas fa-book" style="font-size: small"></i>
+          </a>
+          <input class="align-center" type="text" name="system.damage" value="{{system.damage}}" />
+          {{#if system.damage}}
+          <span style="font-weight: bold; font-style: italic;">{{capitalizeWords system.dmgType}}</span>
+          {{/if}}
         </div>

--- a/tests/feature-damage-roll.test.mjs
+++ b/tests/feature-damage-roll.test.mjs
@@ -7,6 +7,10 @@ const npcItemsTemplateUrl = new URL(
   "../templates/actor/parts/section-npc-items.hbs",
   import.meta.url
 );
+const featureSidebarTemplateUrl = new URL(
+  "../templates/item/parts/sidebar-feature.hbs",
+  import.meta.url
+);
 
 test("Features with damage render a damage roll in chat", async () => {
   const source = await readFile(itemDocumentUrl, "utf8");
@@ -36,5 +40,20 @@ test("NPC Feature rows identify damaging Features with a damage action", async (
   assert.match(
     featuresSection,
     /data-action="displayItem"[\s\S]*?HYP3E\.item\.rollDamage[\s\S]*?fa-droplet/
+  );
+});
+
+test("Feature item sheets expose damage formula and damage type controls", async () => {
+  const template = await readFile(featureSidebarTemplateUrl, "utf8");
+
+  assert.match(
+    template,
+    /<input[^>]+name="system\.damage"[^>]+value="{{system\.damage}}"/,
+    "Feature item sheets must provide an editable damage formula"
+  );
+  assert.match(
+    template,
+    /data-action="setDmgTypes"/,
+    "Feature item sheets must provide the shared damage-type selector"
   );
 });

--- a/tests/feature-damage-roll.test.mjs
+++ b/tests/feature-damage-roll.test.mjs
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const itemDocumentUrl = new URL("../module/documents/item.mjs", import.meta.url);
+const npcItemsTemplateUrl = new URL(
+  "../templates/actor/parts/section-npc-items.hbs",
+  import.meta.url
+);
+
+test("Features with damage render a damage roll in chat", async () => {
+  const source = await readFile(itemDocumentUrl, "utf8");
+  const featureMethodStart = source.indexOf("\n  _renderFeatureSection(");
+  const featureMethodEnd = source.indexOf("\n  _renderWeaponSection(", featureMethodStart);
+  const featureMethod = source.slice(featureMethodStart, featureMethodEnd);
+
+  assert.match(
+    source,
+    /_renderFeatureSection\(itemData,\s*item,\s*actorData\)/,
+    "Feature rendering must receive the item and actor roll data"
+  );
+  assert.match(
+    featureMethod,
+    /this\._renderDamageRoll\(itemData,\s*item,\s*actorData\)/,
+    "Feature chat content must include the shared damage-roll control"
+  );
+});
+
+test("NPC Feature rows identify damaging Features with a damage action", async () => {
+  const template = await readFile(npcItemsTemplateUrl, "utf8");
+  const featuresStart = template.indexOf("{{#each features");
+  const featuresEnd = template.indexOf("</ol>", featuresStart);
+  const featuresSection = template.slice(featuresStart, featuresEnd);
+
+  assert.match(featuresSection, /{{#if item\.system\.damage}}/);
+  assert.match(
+    featuresSection,
+    /data-action="displayItem"[\s\S]*?HYP3E\.item\.rollDamage[\s\S]*?fa-droplet/
+  );
+});


### PR DESCRIPTION
I noted that `Feature` item types had the capability for damage rolls and types, which is certainly useful for Monsters and NPC's, or any feature a referee wants to add that just does static damage.  Enabled that on the 'Feature' item type, added an interactable 'damage' button when there is a damage value present, and added fields to the Item template so it can be edited in the UI directly.

<img width="2236" height="1452" alt="image" src="https://github.com/user-attachments/assets/872ccc2c-16c5-488a-9ab2-b56b9ca4062f" />
