### PR TITLE
Fix: v13 v14 compatability and ContextMenu warnings

### DIFF
--- a/module/apps/class-editor.mjs
+++ b/module/apps/class-editor.mjs
@@ -171,7 +171,7 @@ export class HYP3EClassEditor extends HandlebarsApplicationMixin(ApplicationV2) 
         if (!form) return;
 
         // Collect data
-        const fd = new FormDataExtended(form);
+        const fd = new foundry.applications.ux.FormDataExtended(form);
         const formData = fd.object; // returns a deep object of all form fields
         Hyp3eLogger.info("#addFeature", `Form data:`, formData);
 
@@ -206,7 +206,7 @@ export class HYP3EClassEditor extends HandlebarsApplicationMixin(ApplicationV2) 
         if (!form) return;
 
         // Collect data
-        const fd = new FormDataExtended(form);
+        const fd = new foundry.applications.ux.FormDataExtended(form);
         const formData = fd.object; // returns a deep object of all form fields
         Hyp3eLogger.info("#addItem", `Form data:`, formData);
 
@@ -278,7 +278,7 @@ export class HYP3EClassEditor extends HandlebarsApplicationMixin(ApplicationV2) 
         if (!form) return;
 
         // Collect data
-        const fd = new FormDataExtended(form);
+        const fd = new foundry.applications.ux.FormDataExtended(form);
         const formData = fd.object; // returns a deep object of all form fields
         Hyp3eLogger.info("#saveClass", `Form data:`, formData);
 

--- a/module/apps/turn-advance-actions-config.mjs
+++ b/module/apps/turn-advance-actions-config.mjs
@@ -108,7 +108,7 @@ export class TurnAdvanceActionsConfig extends HandlebarsApplicationMixin(Applica
         if (!form) return;
 
         // Collect data
-        const fd = new FormDataExtended(form);
+        const fd = new foundry.applications.ux.FormDataExtended(form);
         const formData = fd.object; // returns a deep object of all form fields
         Hyp3eLogger.info("#saveActions", `Form data:`, formData);
 

--- a/module/chat/chat.mjs
+++ b/module/chat/chat.mjs
@@ -1,4 +1,5 @@
 import { HYP3E } from "../helpers/config.mjs"
+import { getRollMessageOptions } from "../helpers/foundry-compat.mjs";
 import { Hyp3eLogger } from "../helpers/logger.mjs";
 import { 
     handleDamageRollButtons, 
@@ -47,9 +48,7 @@ export function sendRollToChat(roll, actor, label, content, rollMode) {
     speaker: ChatMessage.getSpeaker({ alias: speaker }),
     flavor: label,
     content: content
-  },{
-    rollMode: rollMode
-  })
+  }, getRollMessageOptions(rollMode))
 }
 
 /**
@@ -78,7 +77,7 @@ export async function renderCustomChat(roll, item, dmgObj, actor, tokenId, label
       footerHTML: footerHTML,
     };
     const template = `${HYP3E.templatePath}/chat/attack-roll.hbs`;
-    let customChat = await renderTemplate(template, templateData);
+    let customChat = await foundry.applications.handlebars.renderTemplate(template, templateData);
 
     // Send to chat
     roll.toMessage({
@@ -86,9 +85,7 @@ export async function renderCustomChat(roll, item, dmgObj, actor, tokenId, label
       speaker: ChatMessage.getSpeaker({ alias: speaker }),
       flavor: label,
       content: customChat
-    },{
-      rollMode: rollMode
-    })
+    }, getRollMessageOptions(rollMode))
 }
 
 /**********************************************************

--- a/module/chat/handlers/crit-handlers.mjs
+++ b/module/chat/handlers/crit-handlers.mjs
@@ -223,7 +223,7 @@ async function rollCritHit(charType, actorId) {
     diceRoll: await roll.render()
   };
   const template = `${HYP3E.templatePath}/chat/crit-roll.hbs`;
-  const html = await renderTemplate(template, templateData);
+  const html = await foundry.applications.handlebars.renderTemplate(template, templateData);
 
   const actor = game.actors.get(actorId) ? game.actors.get(actorId) : null
   if (!actor) {
@@ -374,7 +374,7 @@ async function rollCritMiss(charType, actorId, dmgData = null) {
     diceRoll: await roll.render()
   };
   const template = `${HYP3E.templatePath}/chat/crit-roll.hbs`;
-  const html = await renderTemplate(template, templateData);
+  const html = await foundry.applications.handlebars.renderTemplate(template, templateData);
 
   const actor = game.actors.get(actorId) ? game.actors.get(actorId) : null
   if (!actor) {

--- a/module/chat/handlers/damage-handlers.mjs
+++ b/module/chat/handlers/damage-handlers.mjs
@@ -413,7 +413,7 @@ export async function rollDmgButton(formula, debugDmgRollFormula, baseDmgFormula
   };
 
   const template = `${HYP3E.templatePath}/chat/damage-roll.hbs`;
-  const html = await renderTemplate(template, templateData);
+  const html = await foundry.applications.handlebars.renderTemplate(template, templateData);
 
   // Send to chat
   dmgRoll.toMessage({
@@ -465,7 +465,7 @@ async function rollCriticalDamage(total, extraRoll, damageType, applyDr) {
   };
 
   const template = `${HYP3E.templatePath}/chat/apply-damage.hbs`;
-  const html = await renderTemplate(template, templateData);
+  const html = await foundry.applications.handlebars.renderTemplate(template, templateData);
   const chatData = {
     author: game.user_id,
     content: html
@@ -568,7 +568,7 @@ export async function applyHealthChange(total, damageType = "basic", applyDr = t
   };
 
   const template = `${HYP3E.templatePath}/chat/apply-damage.hbs`;
-  const html = await renderTemplate(template, templateData);
+  const html = await foundry.applications.handlebars.renderTemplate(template, templateData);
 
   const chatData = {
     author: game.user_id,

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -453,7 +453,7 @@ export class Hyp3eItem extends Item {
     const templateData = { content };
 
     const template = `${HYP3E.templatePath}/chat/show-item.hbs`;
-    const itemChat = await renderTemplate(template, templateData);
+    const itemChat = await foundry.applications.handlebars.renderTemplate(template, templateData);
     // Log the rendered chat message
     ChatMessage.create({
       speaker: ChatMessage.getSpeaker({ actor: actorData.actorId }),

--- a/module/helpers/dialog.mjs
+++ b/module/helpers/dialog.mjs
@@ -1,4 +1,5 @@
 import { HYP3E } from "./config.mjs"
+import { getRollModeChoices } from "./foundry-compat.mjs"
 import { Hyp3eLogger } from "./logger.mjs"
 
 export class Hyp3eDialog {
@@ -14,12 +15,12 @@ export class Hyp3eDialog {
       ?? "publicroll";
     let dialogData = {
       dataset: dataset,
-      rollModes: CONFIG.Dice.rollModes,
+      rollModes: getRollModeChoices(),
       rollMode: rollMode
     }
     Hyp3eLogger.info("Hyp3eDialog ShowBasicRollDialog", `Dialog dataset:`, dialogData);
     const template = `${HYP3E.templatePath}/dialog/roll-dialog.hbs`
-    const dialogHtml = await renderTemplate(template, dialogData)
+    const dialogHtml = await foundry.applications.handlebars.renderTemplate(template, dialogData)
 
     // Roll dialog for item and ability checks
     return new Promise((resolve, reject) => {
@@ -32,7 +33,7 @@ export class Hyp3eDialog {
             label: dataset.rollButtonLabel,
             callback: (html) => {
               const formElement = html[0].querySelector('form')
-              const formData = new FormDataExtended(formElement)
+              const formData = new foundry.applications.ux.FormDataExtended(formElement)
               const formDataObj = formData.object
               // No situational modifier? Set it to 0
               if (formDataObj.sitMod == '') { formDataObj.sitMod = 0 }
@@ -73,7 +74,7 @@ export class Hyp3eDialog {
       ?? "publicroll";
     let dialogData = {
       dataset: dataset,
-      rollModes: CONFIG.Dice.rollModes,
+      rollModes: getRollModeChoices(),
       rollMode: rollMode,
       ammoTypes: dataset.carriedAmmo ?? null,
       selectedAmmo: dataset.selectedAmmo ?? null,
@@ -84,7 +85,7 @@ export class Hyp3eDialog {
     // Log the dataset
     Hyp3eLogger.info("Hyp3eDialog ShowAttackRollDialog", `Dialog dataset:`, dataset);
     const template = `${HYP3E.templatePath}/dialog/roll-dialog.hbs`
-    const dialogHtml = await renderTemplate(template, dialogData)
+    const dialogHtml = await foundry.applications.handlebars.renderTemplate(template, dialogData)
 
     // Roll dialog for attacks
     return new Promise((resolve, reject) => {
@@ -97,7 +98,7 @@ export class Hyp3eDialog {
             label: "Attack",
             callback: (html) => {
               const formElement = html[0].querySelector('form')
-              const formData = new FormDataExtended(formElement)
+              const formData = new foundry.applications.ux.FormDataExtended(formElement)
               const formDataObj = formData.object
               // No situational modifier? Set it to 0
               if (formDataObj.sitMod == '') { formDataObj.sitMod = 0 }
@@ -136,12 +137,12 @@ export class Hyp3eDialog {
       // roll: dataset.roll,
       enableRoll: dataset.enableRoll,
       dataset: dataset,
-      rollModes: CONFIG.Dice.rollModes,
+      rollModes: getRollModeChoices(),
       rollMode: rollMode
     }
     Hyp3eLogger.info("Hyp3eDialog ShowSpellcastingDialog", `Dialog dataset:`, dataset);
     const template = `${HYP3E.templatePath}/dialog/roll-dialog.hbs`
-    const dialogHtml = await renderTemplate(template, dialogData)
+    const dialogHtml = await foundry.applications.handlebars.renderTemplate(template, dialogData)
 
     // Roll dialog for casting spells
     return new Promise((resolve, reject) => {
@@ -154,7 +155,7 @@ export class Hyp3eDialog {
             label: "Cast Spell",
             callback: (html) => {
               const formElement = html[0].querySelector('form')
-              const formData = new FormDataExtended(formElement)
+              const formData = new foundry.applications.ux.FormDataExtended(formElement)
               const formDataObj = formData.object
               // No situational modifier? Set it to 0
               if (formDataObj.sitMod == '') { formDataObj.sitMod = 0 }
@@ -192,12 +193,12 @@ export class Hyp3eDialog {
     let dialogData = {
       // roll: dataset.roll,
       dataset: dataset,
-      rollModes: CONFIG.Dice.rollModes,
+      rollModes: getRollModeChoices(),
       rollMode: rollMode
     }
     Hyp3eLogger.info("Hyp3eDialog ShowSaveRollDialog", `Dialog dataset:`, dataset);
     const template = `${HYP3E.templatePath}/dialog/roll-dialog.hbs`
-    const dialogHtml = await renderTemplate(template, dialogData)
+    const dialogHtml = await foundry.applications.handlebars.renderTemplate(template, dialogData)
 
     // Roll dialog for saving throws, with save modifiers
     return new Promise((resolve, reject) => {
@@ -210,7 +211,7 @@ export class Hyp3eDialog {
             label: "Roll Save",
             callback: (html) => {
               const formElement = html[0].querySelector('form')
-              const formData = new FormDataExtended(formElement)
+              const formData = new foundry.applications.ux.FormDataExtended(formElement)
               const formDataObj = formData.object
               // No situational modifier? Set it to 0
               if (formDataObj.sitMod == '') { formDataObj.sitMod = 0 }
@@ -223,7 +224,7 @@ export class Hyp3eDialog {
             label: "Avoidance Mod",
             callback: (html) => {
               const formElement = html[0].querySelector('form')
-              const formData = new FormDataExtended(formElement)
+              const formData = new foundry.applications.ux.FormDataExtended(formElement)
               const formDataObj = formData.object
               formDataObj.avoidMod = dataset.avoidMod
               // No situational modifier? Set it to 0
@@ -237,7 +238,7 @@ export class Hyp3eDialog {
             label: "Poison/Rad Mod",
             callback: (html) => {
               const formElement = html[0].querySelector('form')
-              const formData = new FormDataExtended(formElement)
+              const formData = new foundry.applications.ux.FormDataExtended(formElement)
               const formDataObj = formData.object
               formDataObj.poisonMod = dataset.poisonMod
               // No situational modifier? Set it to 0
@@ -251,7 +252,7 @@ export class Hyp3eDialog {
             label: "Willpower Mod",
             callback: (html) => {
               const formElement = html[0].querySelector('form')
-              const formData = new FormDataExtended(formElement)
+              const formData = new foundry.applications.ux.FormDataExtended(formElement)
               const formDataObj = formData.object
               formDataObj.willMod = dataset.willMod
               // No situational modifier? Set it to 0

--- a/module/helpers/foundry-compat.mjs
+++ b/module/helpers/foundry-compat.mjs
@@ -1,0 +1,28 @@
+/**
+ * Return roll-mode choices in the label-map shape expected by Handlebars selectOptions.
+ * Foundry v14 stores richer mode definitions under CONFIG.ChatMessage.modes, while
+ * Foundry v13 stores a label map under CONFIG.Dice.rollModes.
+ * @param {object} [config=CONFIG] - Foundry's CONFIG object
+ * @returns {Record<string, string>}
+ */
+export function getRollModeChoices(config = CONFIG) {
+  const messageModes = config.ChatMessage?.modes;
+  if (!messageModes) return config.Dice.rollModes;
+
+  return Object.fromEntries(
+    Object.entries(messageModes).map(([mode, definition]) => [
+      mode,
+      typeof definition === "string" ? definition : definition.label
+    ])
+  );
+}
+
+/**
+ * Return the Roll#toMessage option supported by the active Foundry generation.
+ * @param {string} mode - Selected message visibility mode
+ * @param {number} [generation=game.release?.generation] - Foundry generation
+ * @returns {{rollMode: string}|{messageMode: string}}
+ */
+export function getRollMessageOptions(mode, generation = game.release?.generation) {
+  return generation >= 14 ? { messageMode: mode } : { rollMode: mode };
+}

--- a/module/helpers/foundry-compat.mjs
+++ b/module/helpers/foundry-compat.mjs
@@ -26,3 +26,12 @@ export function getRollModeChoices(config = CONFIG) {
 export function getRollMessageOptions(mode, generation = game.release?.generation) {
   return generation >= 14 ? { messageMode: mode } : { rollMode: mode };
 }
+
+/**
+ * Return the mergeObject option that enables deletion/operator processing.
+ * @param {number} [generation=game.release?.generation] - Foundry generation
+ * @returns {{performDeletions: boolean}|{applyOperators: boolean}}
+ */
+export function getMergeObjectDeletionOptions(generation = game.release?.generation) {
+  return generation >= 14 ? { applyOperators: true } : { performDeletions: true };
+}

--- a/module/sheets/actor-sheet-v2.mjs
+++ b/module/sheets/actor-sheet-v2.mjs
@@ -775,20 +775,27 @@ export class Hyp3eActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) 
         }
 
         // Right-click context menu on item entries
-        new foundry.applications.ux.ContextMenu.implementation(this.element, ".item-entry", [
-          {
-            name: game.i18n.localize("HYP3E.item.splitStack"),
-            icon: '<i class="fas fa-scissors"></i>',
-            condition: (target) => {
-              const item = this.actor.items.get(target.dataset.itemId);
-              return item?.system?.quantity?.value > 1;
-            },
-            callback: (target) => {
-              const itemId = target.dataset.itemId;
-              Hyp3eActorSheetV2._splitItemStack.call(this, itemId);
-            }
-          }
-        ], { jQuery: false });
+        const splitStackLabel = game.i18n.localize("HYP3E.item.splitStack");
+        const canSplitStack = (target) => {
+          const item = this.actor.items.get(target.dataset.itemId);
+          return item?.system?.quantity?.value > 1;
+        };
+        const splitStack = (target) => {
+          Hyp3eActorSheetV2._splitItemStack.call(this, target.dataset.itemId);
+        };
+        const splitStackEntry = {
+          icon: '<i class="fas fa-scissors"></i>',
+          ...(Number(game.version.split(".")[0]) >= 14
+            ? { label: splitStackLabel, visible: canSplitStack, onClick: splitStack }
+            : { name: splitStackLabel, condition: canSplitStack, callback: splitStack })
+        };
+
+        new foundry.applications.ux.ContextMenu.implementation(
+          this.element,
+          ".item-entry",
+          [splitStackEntry],
+          { jQuery: false }
+        );
 
         // Log render completion
         Hyp3eLogger.info("HYP3EActorSheetV2 _onRender", `Actor Sheet rendered.`, { context, options, sheet: this });

--- a/module/sheets/actor-sheet-v2.mjs
+++ b/module/sheets/actor-sheet-v2.mjs
@@ -1,4 +1,5 @@
 import { HYP3E } from "../helpers/config.mjs"
+import { getRollModeChoices } from "../helpers/foundry-compat.mjs";
 import { Hyp3eCharacterClass } from "../helpers/character.mjs";
 import { parseGpValue, 
           buyFromMerchant,
@@ -499,7 +500,7 @@ export class Hyp3eActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) 
     context.languages = CONFIG.HYP3E.languages
 
     // System-defined roll modes
-    context.rollModes = CONFIG.Dice.rollModes
+    context.rollModes = getRollModeChoices()
 
     // Set encumbrance flags for the sheet
     if (CONFIG.HYP3E.enableEncumbrance) {
@@ -779,15 +780,15 @@ export class Hyp3eActorSheetV2 extends HandlebarsApplicationMixin(ActorSheetV2) 
             name: game.i18n.localize("HYP3E.item.splitStack"),
             icon: '<i class="fas fa-scissors"></i>',
             condition: (target) => {
-              const item = this.actor.items.get($(target).data("itemId"));
+              const item = this.actor.items.get(target.dataset.itemId);
               return item?.system?.quantity?.value > 1;
             },
             callback: (target) => {
-              const itemId = $(target).data("itemId");
+              const itemId = target.dataset.itemId;
               Hyp3eActorSheetV2._splitItemStack.call(this, itemId);
             }
           }
-        ]);
+        ], { jQuery: false });
 
         // Log render completion
         Hyp3eLogger.info("HYP3EActorSheetV2 _onRender", `Actor Sheet rendered.`, { context, options, sheet: this });

--- a/module/sheets/item-sheet-v2.mjs
+++ b/module/sheets/item-sheet-v2.mjs
@@ -1,4 +1,5 @@
 import { HYP3E } from "../helpers/config.mjs"
+import { getRollModeChoices } from "../helpers/foundry-compat.mjs";
 import { Hyp3eLogger } from "../helpers/logger.mjs";
 import {onManageActiveEffectV2, prepareActiveEffectCategories} from "../helpers/effects.mjs";
 import HYP3EItemSetAnnotations from "../apps/item-set-annotations.mjs";
@@ -277,7 +278,7 @@ export class Hyp3eItemSheetV2 extends HandlebarsApplicationMixin(ItemSheetV2) {
     context.weaponAnnotations = CONFIG.HYP3E.weaponAnnotations;
     context.damageTypes = CONFIG.HYP3E.damageTypes;
     context.blindRollOpts = CONFIG.HYP3E.blindRollOpts;
-    context.rollModes = CONFIG.Dice.rollModes;
+    context.rollModes = getRollModeChoices();
     context.saveThrows = CONFIG.HYP3E.saves;
 
     // This is mostly an issue with new compendium items

--- a/module/sheets/item-sheet-v2.mjs
+++ b/module/sheets/item-sheet-v2.mjs
@@ -1,5 +1,8 @@
 import { HYP3E } from "../helpers/config.mjs"
-import { getRollModeChoices } from "../helpers/foundry-compat.mjs";
+import {
+  getMergeObjectDeletionOptions,
+  getRollModeChoices
+} from "../helpers/foundry-compat.mjs";
 import { Hyp3eLogger } from "../helpers/logger.mjs";
 import {onManageActiveEffectV2, prepareActiveEffectCategories} from "../helpers/effects.mjs";
 import HYP3EItemSetAnnotations from "../apps/item-set-annotations.mjs";
@@ -469,7 +472,7 @@ export class Hyp3eItemSheetV2 extends HandlebarsApplicationMixin(ItemSheetV2) {
 
     // Merge updated formDataObj back into formData.object, and log the data
     Hyp3eLogger.info("Hyp3eItemSheetV2 _processFormData", `Updated form data:`, formDataObj);
-    foundry.utils.mergeObject(formData.object, formDataObj, {performDeletions: true});
+    foundry.utils.mergeObject(formData.object, formDataObj, getMergeObjectDeletionOptions());
     Hyp3eLogger.info("Hyp3eItemSheetV2 _processFormData", `Merged form data:`, formData);
 
     return super._processFormData(event, form, formData);

--- a/tests/foundry-compat.test.mjs
+++ b/tests/foundry-compat.test.mjs
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  getRollMessageOptions,
+  getRollModeChoices
+} from "../module/helpers/foundry-compat.mjs";
+
+test("Foundry v13 uses CONFIG.Dice.rollModes and Roll#toMessage rollMode", () => {
+  const rollModes = {
+    publicroll: "CHAT.RollPublic",
+    gmroll: "CHAT.RollPrivate"
+  };
+  const config = {
+    ChatMessage: {},
+    Dice: { rollModes }
+  };
+
+  assert.equal(getRollModeChoices(config), rollModes);
+  assert.deepEqual(getRollMessageOptions("gmroll", 13), { rollMode: "gmroll" });
+});
+
+test("Foundry v14 converts CONFIG.ChatMessage.modes and uses messageMode", () => {
+  const config = {
+    ChatMessage: {
+      modes: {
+        public: { label: "CHAT.RollPublic", icon: "fa-users" },
+        gm: { label: "CHAT.RollPrivate", icon: "fa-user-shield" }
+      }
+    },
+    Dice: {}
+  };
+
+  assert.deepEqual(getRollModeChoices(config), {
+    public: "CHAT.RollPublic",
+    gm: "CHAT.RollPrivate"
+  });
+  assert.deepEqual(getRollMessageOptions("gm", 14), { messageMode: "gm" });
+});

--- a/tests/foundry-compat.test.mjs
+++ b/tests/foundry-compat.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  getMergeObjectDeletionOptions,
   getRollMessageOptions,
   getRollModeChoices
 } from "../module/helpers/foundry-compat.mjs";
@@ -36,4 +37,15 @@ test("Foundry v14 converts CONFIG.ChatMessage.modes and uses messageMode", () =>
     gm: "CHAT.RollPrivate"
   });
   assert.deepEqual(getRollMessageOptions("gm", 14), { messageMode: "gm" });
+});
+
+test("mergeObject deletion processing uses the option supported by each generation", () => {
+  assert.deepEqual(
+    getMergeObjectDeletionOptions(13),
+    { performDeletions: true }
+  );
+  assert.deepEqual(
+    getMergeObjectDeletionOptions(14),
+    { applyOperators: true }
+  );
 });

--- a/tests/foundry-compat.test.mjs
+++ b/tests/foundry-compat.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
 import test from "node:test";
 
 import {
@@ -6,6 +7,11 @@ import {
   getRollMessageOptions,
   getRollModeChoices
 } from "../module/helpers/foundry-compat.mjs";
+
+const actorSheetUrl = new URL(
+  "../module/sheets/actor-sheet-v2.mjs",
+  import.meta.url
+);
 
 test("Foundry v13 uses CONFIG.Dice.rollModes and Roll#toMessage rollMode", () => {
   const rollModes = {
@@ -48,4 +54,17 @@ test("mergeObject deletion processing uses the option supported by each generati
     getMergeObjectDeletionOptions(14),
     { applyOperators: true }
   );
+});
+
+test("actor item context menus use the entry API supported by each generation", async () => {
+  const source = await readFile(actorSheetUrl, "utf8");
+  const menuStart = source.indexOf("// Right-click context menu on item entries");
+  const menuEnd = source.indexOf("// Log render completion", menuStart);
+  const contextMenu = source.slice(menuStart, menuEnd);
+
+  assert.match(contextMenu, /Number\(game\.version\.split\("\."\)\[0\]\) >= 14/);
+  assert.match(contextMenu, /label: splitStackLabel, visible: canSplitStack, onClick: splitStack/);
+  assert.match(contextMenu, /name: splitStackLabel, condition: canSplitStack, callback: splitStack/);
+  assert.match(contextMenu, /\{ jQuery: false \}/);
+  assert.doesNotMatch(contextMenu, /\$\(target\)/);
 });


### PR DESCRIPTION
A PR fix to address the versioning compatibility warnings in the `hyp3e v4.0.3` dev branch.  

## Summary

- Use version-aware roll-mode configuration and chat-message options via the `getRollMessageOptions` function
- Replace deprecated global and chat APIs with v13/v14-compatible equivalents.
- Select the supported `mergeObject` deletion option for each Foundry generation.
- Update actor item ContextMenus for native HTMLElement callbacks.
- Use the appropriate ContextMenu entry properties on Foundry v13 and v14.
- Add regression coverage for both supported Foundry generations.

I have a separate PR I'll be submitting that has all the outstanding roll dialogs ported to an ApplicationV2 rollable dialog window.

Thank you for all your work maintaining the hyp3e system for us, @thurianknight 